### PR TITLE
publish to gradle plugin registry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,15 +4,20 @@ plugins {
   id 'signing'
   id 'net.researchgate.release' version '2.8.1'
   id 'io.codearte.nexus-staging' version '0.21.2'
+  id "com.gradle.plugin-publish" version "0.10.1"
 }
 
 apply plugin: 'maven'
+
+def pluginDescription = 'Scan, evaluate and audit Gradle projects using Sonatype platforms'
 
 gradlePlugin {
   plugins {
     scan {
       id = 'org.sonatype.gradle.plugins.scan'
       implementationClass = 'org.sonatype.gradle.plugins.scan.ScanPlugin'
+      displayName = project.name
+      description = pluginDescription
     }
   }
 }
@@ -103,6 +108,17 @@ check.dependsOn integrationTest
 if ('do-release'.equals(System.getenv('CIRCLE_JOB'))) {
   publishing {
     afterEvaluate {
+      def pluginUrl = 'https://github.com/sonatype-nexus-community/scan-gradle-plugin'
+
+      pluginBundle {
+        website = pluginUrl
+        vcsUrl = pluginUrl
+        description = pluginDescription
+        tags = ['sonatype', 'scan', 'dependencies', 'ossindex', 'iq server']
+        System.setProperty('gradle.publish.key', System.getenv('GRADLE_PUBLISH_KEY'))
+        System.setProperty('gradle.publish.secret', System.getenv('GRADLE_PUBLISH_SECRET'))
+      }
+
       release {
         // avoid infinite CircleCI builds triggered by release commits
         preCommitText = '[skip ci] '
@@ -137,7 +153,7 @@ if ('do-release'.equals(System.getenv('CIRCLE_JOB'))) {
         withType(MavenPublication) {
           pom {
             name = project.name
-            description = 'Scan, evaluate and audit Gradle projects using Sonatype platforms'
+            description = pluginDescription
             url = 'https://github.com/sonatype-nexus-community/scan-gradle-plugin'
             organization {
               name = 'Sonatype'
@@ -200,4 +216,5 @@ if ('do-release'.equals(System.getenv('CIRCLE_JOB'))) {
 
   afterReleaseBuild.dependsOn publish
   publish.finalizedBy closeAndReleaseRepository
+  publish.finalizedBy publishPlugins
 }


### PR DESCRIPTION
Publish plugin to the [gradle plugin registry](https://plugins.gradle.org).

Not at all sure if the approach I took to programmatically set the required system properties for publishing will work. Please holler if you have thoughts on this.

After approval, I will merge to master and thrash about some more.

It relates to the following issue #s:
* Partial #7 

cc @bhamail / @DarthHater / @guillermo-varela
