### PR TITLE
Experiment with subsets of parameterized tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,11 @@ jobs:
       - configure-git
       - gradle-release
 
+it-defaults: &it-defaults
+      executor: openjdk-8-executor
+      test_results_path: build/test-results
+      reports_path: build/reports
+
 workflows:
   checkout-run_task:
     jobs:
@@ -43,20 +48,42 @@ workflows:
           test_results_path: build/test-results
           reports_path: build/reports
           test_command: test --no-daemon --debug --max-workers 2
-  integration-test:
-    jobs:
-      - gradle/test:
-          executor: openjdk-8-executor
-          test_results_path: build/test-results
-          reports_path: build/reports
-          test_command: integrationTest --fail-fast --no-daemon -Dorg.gradle.daemon=false  --info
+
+# Running all ITs at once was causing intermittent memory errors
+#  integration-test:
+#    jobs:
+#      - gradle/test:
+#          executor: openjdk-8-executor
+#          test_results_path: build/test-results
+#          reports_path: build/reports
+#          test_command: --fail-fast --no-daemon -Dorg.gradle.daemon=false --info integrationTest
+
   it1:
     jobs:
-      - gradle/test:
-          executor: openjdk-8-executor
-          test_results_path: build/test-results
-          reports_path: build/reports
-          test_command: it1 --fail-fast --no-daemon -Dorg.gradle.daemon=false  --info
+    - gradle/test:
+          <<: *it-defaults
+          test_command: --no-daemon -Dorg.gradle.daemon=false --info it1
+  it2:
+    jobs:
+    - gradle/test:
+          <<: *it-defaults
+          test_command: --no-daemon -Dorg.gradle.daemon=false --info it2
+  it3:
+    jobs:
+    - gradle/test:
+          <<: *it-defaults
+          test_command: --no-daemon -Dorg.gradle.daemon=false --info it3
+  it4:
+    jobs:
+    - gradle/test:
+          <<: *it-defaults
+          test_command: --no-daemon -Dorg.gradle.daemon=false --info it4
+  it5:
+    jobs:
+    - gradle/test:
+          <<: *it-defaults
+          test_command: --no-daemon -Dorg.gradle.daemon=false --info it5
+
   release:
     jobs:
       - approve-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,13 @@ workflows:
           test_results_path: build/test-results
           reports_path: build/reports
           test_command: integrationTest --fail-fast --no-daemon -Dorg.gradle.daemon=false  --info
+  it1:
+    jobs:
+      - gradle/test:
+          executor: openjdk-8-executor
+          test_results_path: build/test-results
+          reports_path: build/reports
+          test_command: it1 --fail-fast --no-daemon -Dorg.gradle.daemon=false  --info
   release:
     jobs:
       - approve-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
           reports_path: build/reports
           test_command: test --no-daemon --debug --max-workers 2
 
-# Running all ITs at once was causing intermittent memory errors
+# Running all ITs at once was causing intermittent memory errors (as per below config), so we split ITs into batches.
 #  integration-test:
 #    jobs:
 #      - gradle/test:

--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -10,57 +10,24 @@ sourceSets {
 task integrationTest(type: Test) {
   description = 'Runs the integration tests.'
   group = 'verification'
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  classpath = sourceSets.integrationTest.runtimeClasspath
-  maxHeapSize = '1536m'
-  mustRunAfter test
 }
 
-// small batches of ITs to avoid memory errors on CI. will be run in parallel workflows.
-task it1(type: Test) {
-  description = 'Runs small batch of integration tests.'
-  group = 'verification'
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  classpath = sourceSets.integrationTest.runtimeClasspath
-  maxHeapSize = '1536m'
-  includes = ['**/ScanIT_Gradle_Versions_4_2*.class']
-  mustRunAfter test
-}
-task it2(type: Test) {
-  description = 'Runs small batch of integration tests.'
-  group = 'verification'
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  classpath = sourceSets.integrationTest.runtimeClasspath
-  maxHeapSize = '1536m'
-  includes = ['**/ScanIT_Gradle_Versions_4_5*.class']
-  mustRunAfter test
-}
-task it3(type: Test) {
-  description = 'Runs small batch of integration tests.'
-  group = 'verification'
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  classpath = sourceSets.integrationTest.runtimeClasspath
-  maxHeapSize = '1536m'
-  includes = ['**/ScanIT_Gradle_Versions_4_8*.class']
-  mustRunAfter test
-}
-task it4(type: Test) {
-  description = 'Runs small batch of integration tests.'
-  group = 'verification'
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  classpath = sourceSets.integrationTest.runtimeClasspath
-  maxHeapSize = '1536m'
-  includes = ['**/ScanIT_Gradle_Versions_5_1*.class']
-  mustRunAfter test
-}
-task it5(type: Test) {
-  description = 'Runs small batch of integration tests.'
-  group = 'verification'
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  classpath = sourceSets.integrationTest.runtimeClasspath
-  maxHeapSize = '1536m'
-  includes = ['**/ScanIT_Gradle_Versions_5_4*.class']
-  mustRunAfter test
+['**/ScanIT_Gradle_Versions_4_2*.class',
+ '**/ScanIT_Gradle_Versions_4_5*.class',
+ '**/ScanIT_Gradle_Versions_4_8*.class',
+ '**/ScanIT_Gradle_Versions_5_1*.class',
+ '**/ScanIT_Gradle_Versions_5_4*.class'].eachWithIndex { className, index ->
+  task "it${index + 1}"(type: Test) {
+    includes = [className]
+    description = "Runs the integration tests on class $className."
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    maxHeapSize = '1536m'
+    mustRunAfter test
+  }
+
+  integrationTest.dependsOn "it${index + 1}"
 }
 
 check.dependsOn integrationTest

--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -16,4 +16,15 @@ task integrationTest(type: Test) {
   mustRunAfter test
 }
 
+task it1(type: Test) {
+  description = 'Runs small batch of integration tests.'
+  group = 'verification'
+  testClassesDirs = sourceSets.integrationTest.output.classesDirs
+  classpath = sourceSets.integrationTest.runtimeClasspath
+  maxHeapSize = '1536m'
+  mustRunAfter test
+  includes = '**/ScanIT_Gradle_Versions_4_2*.class'
+
+}
+
 check.dependsOn integrationTest

--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -23,7 +23,8 @@ task it1(type: Test) {
   classpath = sourceSets.integrationTest.runtimeClasspath
   maxHeapSize = '1536m'
   mustRunAfter test
-  includes = '**/ScanIT_Gradle_Versions_4_2*.class'
+  // @TODO the setting below is wrong, but not sure how to filter the tests...
+  //includes = '**/ScanIT_Gradle_Versions_4_2*.class'
 
 }
 

--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -16,16 +16,51 @@ task integrationTest(type: Test) {
   mustRunAfter test
 }
 
+// small batches of ITs to avoid memory errors on CI. will be run in parallel workflows.
 task it1(type: Test) {
   description = 'Runs small batch of integration tests.'
   group = 'verification'
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
   maxHeapSize = '1536m'
+  includes = ['**/ScanIT_Gradle_Versions_4_2*.class']
   mustRunAfter test
-  // @TODO the setting below is wrong, but not sure how to filter the tests...
-  //includes = '**/ScanIT_Gradle_Versions_4_2*.class'
-
+}
+task it2(type: Test) {
+  description = 'Runs small batch of integration tests.'
+  group = 'verification'
+  testClassesDirs = sourceSets.integrationTest.output.classesDirs
+  classpath = sourceSets.integrationTest.runtimeClasspath
+  maxHeapSize = '1536m'
+  includes = ['**/ScanIT_Gradle_Versions_4_5*.class']
+  mustRunAfter test
+}
+task it3(type: Test) {
+  description = 'Runs small batch of integration tests.'
+  group = 'verification'
+  testClassesDirs = sourceSets.integrationTest.output.classesDirs
+  classpath = sourceSets.integrationTest.runtimeClasspath
+  maxHeapSize = '1536m'
+  includes = ['**/ScanIT_Gradle_Versions_4_8*.class']
+  mustRunAfter test
+}
+task it4(type: Test) {
+  description = 'Runs small batch of integration tests.'
+  group = 'verification'
+  testClassesDirs = sourceSets.integrationTest.output.classesDirs
+  classpath = sourceSets.integrationTest.runtimeClasspath
+  maxHeapSize = '1536m'
+  includes = ['**/ScanIT_Gradle_Versions_5_1*.class']
+  mustRunAfter test
+}
+task it5(type: Test) {
+  description = 'Runs small batch of integration tests.'
+  group = 'verification'
+  testClassesDirs = sourceSets.integrationTest.output.classesDirs
+  classpath = sourceSets.integrationTest.runtimeClasspath
+  maxHeapSize = '1536m'
+  includes = ['**/ScanIT_Gradle_Versions_5_4*.class']
+  mustRunAfter test
 }
 
 check.dependsOn integrationTest

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_4_2_to_4_4.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_4_2_to_4_4.java
@@ -1,0 +1,19 @@
+package org.sonatype.gradle.plugins.scan;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class ScanIT_Gradle_Versions_4_2_to_4_4
+    extends ScanPluginIntegrationTestBase
+{
+  @Parameterized.Parameters(name = "Version: {0}")
+  public static List<String> data() {
+    return Arrays.asList("4.2.1", "4.3.1", "4.4.1");
+  }
+
+  public ScanIT_Gradle_Versions_4_2_to_4_4(final String gradleVersion) {
+    super(gradleVersion);
+  }
+}

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_4_5_to_4_7.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_4_5_to_4_7.java
@@ -1,0 +1,19 @@
+package org.sonatype.gradle.plugins.scan;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class ScanIT_Gradle_Versions_4_5_to_4_7
+    extends ScanPluginIntegrationTestBase
+{
+  @Parameterized.Parameters(name = "Version: {0}")
+  public static List<String> data() {
+    return Arrays.asList("4.5.1", "4.6", "4.7");
+  }
+
+  public ScanIT_Gradle_Versions_4_5_to_4_7(final String gradleVersion) {
+    super(gradleVersion);
+  }
+}

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_4_8_to_4_10.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_4_8_to_4_10.java
@@ -1,0 +1,19 @@
+package org.sonatype.gradle.plugins.scan;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class ScanIT_Gradle_Versions_4_8_to_4_10
+    extends ScanPluginIntegrationTestBase
+{
+  @Parameterized.Parameters(name = "Version: {0}")
+  public static List<String> data() {
+    return Arrays.asList("4.8.1", "4.9", "4.10.3");
+  }
+
+  public ScanIT_Gradle_Versions_4_8_to_4_10(final String gradleVersion) {
+    super(gradleVersion);
+  }
+}

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_5_1_to_5_3.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_5_1_to_5_3.java
@@ -1,0 +1,19 @@
+package org.sonatype.gradle.plugins.scan;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class ScanIT_Gradle_Versions_5_1_to_5_3
+    extends ScanPluginIntegrationTestBase
+{
+  @Parameterized.Parameters(name = "Version: {0}")
+  public static List<String> data() {
+    return Arrays.asList("5.1.1", "5.2.1", "5.3.1");
+  }
+
+  public ScanIT_Gradle_Versions_5_1_to_5_3(final String gradleVersion) {
+    super(gradleVersion);
+  }
+}

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_5_4_to_6_0.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_5_4_to_6_0.java
@@ -1,0 +1,19 @@
+package org.sonatype.gradle.plugins.scan;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class ScanIT_Gradle_Versions_5_4_to_6_0
+    extends ScanPluginIntegrationTestBase
+{
+  @Parameterized.Parameters(name = "Version: {0}")
+  public static List<String> data() {
+    return Arrays.asList("5.4.1", "5.6.4", "6.0.1");
+  }
+
+  public ScanIT_Gradle_Versions_5_4_to_6_0(final String gradleVersion) {
+    super(gradleVersion);
+  }
+}

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
@@ -21,8 +21,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.gradle.testkit.runner.BuildResult;
@@ -41,17 +39,18 @@ import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 
 @RunWith(Parameterized.class)
-public class ScanPluginIntegrationTest
+public abstract class ScanPluginIntegrationTestBase
 {
-  @Parameterized.Parameters(name = "Version: {0}")
-  public static List<String> data() {
-    return Arrays.asList("4.2.1", "4.3.1", "4.4.1", "4.5.1", "4.6", "4.7", "4.8.1", "4.9", "4.10.3", "5.1.1", "5.2.1",
-        "5.3.1", "5.4.1", "5.6.4", "6.0.1");
-  }
+   /*
+   Parameters are declared in subclasses in order run subsets of Gradle versions to avoid Memory errors on CI.
+   Original list of versions:
+      return Arrays.asList("4.2.1", "4.3.1", "4.4.1", "4.5.1", "4.6", "4.7", "4.8.1", "4.9", "4.10.3", "5.1.1", "5.2.1",
+          "5.3.1", "5.4.1", "5.6.4", "6.0.1");
+   */
 
   private final String gradleVersion;
 
-  public ScanPluginIntegrationTest(String gradleVersion) {
+  public ScanPluginIntegrationTestBase(String gradleVersion) {
     this.gradleVersion = gradleVersion;
   }
 


### PR DESCRIPTION
Looking for a way to shrink to total memory used by this parameterized test.
This PR chunks the Gradle versions into batches of 3, but it appears to make no difference as the memory issue still pops up.

Suggestions welcome!

It relates to the following issue #s:
* Fixes #11

cc @bhamail / @DarthHater / @guillermo-varela
