### PR TITLE
Tests to ensure Gradle 3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,21 @@ workflows:
     - gradle/test:
           <<: *it-defaults
           test_command: --no-daemon -Dorg.gradle.daemon=false --info it5
+  it6:
+    jobs:
+    - gradle/test:
+          <<: *it-defaults
+          test_command: --no-daemon -Dorg.gradle.daemon=false --info it6
+  it7:
+    jobs:
+    - gradle/test:
+          <<: *it-defaults
+          test_command: --no-daemon -Dorg.gradle.daemon=false --info it7
+  it8:
+    jobs:
+    - gradle/test:
+          <<: *it-defaults
+          test_command: --no-daemon -Dorg.gradle.daemon=false --info it8
 
   release:
     jobs:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you want to save some time, skip integration tests:
 > ./gradlew integrationTest
 
 ## Compatibility
-The plugin can be used on projects with Gradle 4.2.1 or higher (local installation or wrapper) and Java 8 installed locally.
+The plugin can be used on projects with Gradle 3.0 or higher (local installation or wrapper) and Java 8 installed locally.
 
 ## Supported Programming Languages
 Gradle can be used to build projects developed in various programming languages. This plugin supports:

--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -12,7 +12,10 @@ task integrationTest(type: Test) {
   group = 'verification'
 }
 
-['**/ScanIT_Gradle_Versions_4_2*.class',
+['**/ScanIT_Gradle_Versions_3_0*.class',
+ '**/ScanIT_Gradle_Versions_3_4*.class',
+ '**/ScanIT_Gradle_Versions_4_0*.class',
+ '**/ScanIT_Gradle_Versions_4_2*.class',
  '**/ScanIT_Gradle_Versions_4_5*.class',
  '**/ScanIT_Gradle_Versions_4_8*.class',
  '**/ScanIT_Gradle_Versions_5_1*.class',

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_3_0_to_3_3.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_3_0_to_3_3.java
@@ -1,0 +1,20 @@
+package org.sonatype.gradle.plugins.scan;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class ScanIT_Gradle_Versions_3_0_to_3_3
+    extends ScanPluginIntegrationTestBase
+{
+  @Parameterized.Parameters(name = "Version: {0}")
+  public static List<String> data() {
+    return Arrays.asList("3.0", "3.2.1", "3.3");
+  }
+
+  public ScanIT_Gradle_Versions_3_0_to_3_3(final String gradleVersion) {
+    super(gradleVersion);
+    this.useLegacySyntax = true;
+  }
+}

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_3_4_to_3_5.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_3_4_to_3_5.java
@@ -1,0 +1,19 @@
+package org.sonatype.gradle.plugins.scan;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class ScanIT_Gradle_Versions_3_4_to_3_5
+    extends ScanPluginIntegrationTestBase
+{
+  @Parameterized.Parameters(name = "Version: {0}")
+  public static List<String> data() {
+    return Arrays.asList("3.4", "3.4.1", "3.5.1");
+  }
+
+  public ScanIT_Gradle_Versions_3_4_to_3_5(final String gradleVersion) {
+    super(gradleVersion);
+  }
+}

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_4_0_to_4_1.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_4_0_to_4_1.java
@@ -1,0 +1,19 @@
+package org.sonatype.gradle.plugins.scan;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class ScanIT_Gradle_Versions_4_0_to_4_1
+    extends ScanPluginIntegrationTestBase
+{
+  @Parameterized.Parameters(name = "Version: {0}")
+  public static List<String> data() {
+    return Arrays.asList("4.0", "4.0.2", "4.1");
+  }
+
+  public ScanIT_Gradle_Versions_4_0_to_4_1(final String gradleVersion) {
+    super(gradleVersion);
+  }
+}

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
@@ -41,14 +41,13 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 @RunWith(Parameterized.class)
 public abstract class ScanPluginIntegrationTestBase
 {
-   /*
-   Parameters are declared in subclasses in order run subsets of Gradle versions to avoid Memory errors on CI.
-   Original list of versions:
-      return Arrays.asList("4.2.1", "4.3.1", "4.4.1", "4.5.1", "4.6", "4.7", "4.8.1", "4.9", "4.10.3", "5.1.1", "5.2.1",
-          "5.3.1", "5.4.1", "5.6.4", "6.0.1");
+  /*
+   * Parameters are declared in subclasses in order run subsets of Gradle versions to avoid Memory errors on CI.
    */
 
   private final String gradleVersion;
+
+  protected boolean useLegacySyntax;
 
   public ScanPluginIntegrationTestBase(String gradleVersion) {
     this.gradleVersion = gradleVersion;
@@ -161,7 +160,8 @@ public abstract class ScanPluginIntegrationTestBase
   }
 
   private void writeFile(File destination, String resourceName) throws IOException {
-    try (InputStream contentStream = getClass().getClassLoader().getResourceAsStream(resourceName);
+    String resource = useLegacySyntax ? "legacy-syntax" + File.separator + resourceName : resourceName;
+    try (InputStream contentStream = getClass().getClassLoader().getResourceAsStream(resource);
         BufferedWriter output = new BufferedWriter(new FileWriter(destination))) {
       assert contentStream != null;
       IOUtils.copy(contentStream, output, StandardCharsets.UTF_8);

--- a/src/integTest/resources/control.gradle
+++ b/src/integTest/resources/control.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'java-library'
+  id 'java'
   id 'org.sonatype.gradle.plugins.scan'
 }
 

--- a/src/integTest/resources/legacy-syntax/control.gradle
+++ b/src/integTest/resources/legacy-syntax/control.gradle
@@ -7,7 +7,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'commons-collections:commons-collections:3.1'
+  compile 'commons-collections:commons-collections:3.1'
 }
 
 nexusIQScan {
@@ -16,10 +16,8 @@ nexusIQScan {
   password = 'admin123'
   applicationId = 'testing-gradle-plugin'
   simulationEnabled = true
-  simulatedPolicyActionId = 'fail'
 }
 
 ossIndexAudit {
   simulationEnabled = true
-  simulatedVulnerabityFound = true
 }

--- a/src/integTest/resources/legacy-syntax/missing-scan.gradle
+++ b/src/integTest/resources/legacy-syntax/missing-scan.gradle
@@ -1,0 +1,3 @@
+plugins {
+  id 'org.sonatype.gradle.plugins.scan'
+}

--- a/src/integTest/resources/legacy-syntax/policy-fail.gradle
+++ b/src/integTest/resources/legacy-syntax/policy-fail.gradle
@@ -7,7 +7,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'commons-collections:commons-collections:3.1'
+  compile 'commons-collections:commons-collections:3.1'
 }
 
 nexusIQScan {

--- a/src/integTest/resources/legacy-syntax/policy-warn.gradle
+++ b/src/integTest/resources/legacy-syntax/policy-warn.gradle
@@ -7,7 +7,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'commons-collections:commons-collections:3.1'
+  compile 'commons-collections:commons-collections:3.1'
 }
 
 nexusIQScan {
@@ -16,10 +16,5 @@ nexusIQScan {
   password = 'admin123'
   applicationId = 'testing-gradle-plugin'
   simulationEnabled = true
-  simulatedPolicyActionId = 'fail'
-}
-
-ossIndexAudit {
-  simulationEnabled = true
-  simulatedVulnerabityFound = true
+  simulatedPolicyActionId = 'warn'
 }

--- a/src/integTest/resources/policy-warn.gradle
+++ b/src/integTest/resources/policy-warn.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'java-library'
+  id 'java'
   id 'org.sonatype.gradle.plugins.scan'
 }
 


### PR DESCRIPTION
Adds tests to ensure this plugin supports Gradle 3.0, that means we support the old dependencies syntax (`compile` instead of `implementation`)

This pull request makes the following changes:
* Add integration tests with Gradle versions below 4.2
* No changes were needed on the production code as we were using safe to use Gradle APIs :)

It relates to the following issue #s:
* Fixes #19 

cc @bhamail / @DarthHater / @guillermo-varela
