### PR TITLE
24: Shade and relocate IQ dependencies to avoid version conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
+
 plugins {
   id 'java-gradle-plugin'
   id 'maven-publish'
   id 'signing'
   id 'net.researchgate.release' version '2.8.1'
   id 'io.codearte.nexus-staging' version '0.21.2'
-  id "com.gradle.plugin-publish" version "0.10.1"
+  id 'com.gradle.plugin-publish' version '0.10.1'
+  id 'com.github.johnrengelman.shadow' version '5.2.0'
 }
 
 apply plugin: 'maven'
@@ -50,8 +53,19 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
   from javadoc.destinationDir
 }
 
+shadowJar {
+  mergeServiceFiles()
+  classifier = null
+}
+
+task relocateShadowJar(type: ConfigureShadowRelocation) {
+  target = tasks.shadowJar
+}
+
+tasks.shadowJar.dependsOn tasks.relocateShadowJar
+
 artifacts {
-  archives jar
+  archives shadowJar
   archives sourceJar
   archives javadocJar
 }
@@ -61,11 +75,11 @@ repositories {
 }
 
 dependencies {
-  localGroovy()
-  gradleApi()
+  shadow localGroovy()
+  shadow gradleApi()
 
   implementation "com.sonatype.nexus:nexus-platform-api:$nexusJavaApiVersion:internal"
-  implementation "org.sonatype.ossindex:ossindex-service-client:$ossIndexClientVersion"
+  shadow "org.sonatype.ossindex:ossindex-service-client:$ossIndexClientVersion"
 
   testCompile gradleTestKit()
   testCompile "junit:junit:$junitVersion"
@@ -84,6 +98,13 @@ processResources {
 
 test {
   maxHeapSize = '512m'
+}
+
+sourceSets {
+  test {
+    compileClasspath += sourceSets.main.output + configurations.shadow
+    runtimeClasspath += output + compileClasspath
+  }
 }
 
 // configure deployment if performing release
@@ -132,6 +153,10 @@ if ('do-release'.equals(System.getenv('CIRCLE_JOB'))) {
       }
 
       publications {
+        shadow(MavenPublication) { publication ->
+          project.shadow.component(publication)
+        }
+
         withType(MavenPublication) {
           pom {
             name = project.name
@@ -166,13 +191,13 @@ if ('do-release'.equals(System.getenv('CIRCLE_JOB'))) {
               }
             }
           }
-  
+
           artifactId = project.name
-  
+
           artifact(sourceJar) {
             classifier = 'sources'
           }
-  
+
           artifact(javadocJar) {
             classifier = 'javadoc'
           }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020-present Sonatype, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+         http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration debug="false">
+  <appender name="CONSOLE" class="shadow.ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
+  </root>
+</configuration>


### PR DESCRIPTION
This pull request makes the following changes:
Use the shadow plugin to Shade and relocate dependencies from `nexus-platform-api` as that library uses a shaded (but not relocated) Apache HTTP Client 4.5.3 while `ossindex-service-client` uses 4.5.5

An attempt was made to shade all dependencies, but then the old library version was shaded into the resulting jar.

Local tests using both IQ Server and OSS Index worked, unit tests also work but so far I wasn't able to add the non-merged dependencies into the integration tests classpath.

It relates to the following issue #s:
* Fixes #24 