### PR TITLE
Dependencies as tree for OSS Index

### DIFF
--- a/src/integTest/resources/legacy-syntax/transitive-dependencies.gradle
+++ b/src/integTest/resources/legacy-syntax/transitive-dependencies.gradle
@@ -1,0 +1,11 @@
+plugins {
+  id 'java'
+  id 'org.sonatype.gradle.plugins.scan'
+}
+
+repositories {
+  mavenCentral()
+}
+dependencies {
+  compile 'junit:junit:4.12'
+}

--- a/src/integTest/resources/transitive-dependencies.gradle
+++ b/src/integTest/resources/transitive-dependencies.gradle
@@ -1,0 +1,11 @@
+plugins {
+  id 'java'
+  id 'org.sonatype.gradle.plugins.scan'
+}
+
+repositories {
+  mavenCentral()
+}
+dependencies {
+  implementation 'junit:junit:4.12'
+}

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -28,6 +28,7 @@ import com.sonatype.insight.scan.module.model.Module;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting;
 
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME;
@@ -36,6 +37,14 @@ public class DependenciesFinder
 {
   private static final Set<String> CONFIGURATION_NAMES =
       new HashSet<>(Arrays.asList(COMPILE_CLASSPATH_CONFIGURATION_NAME, "releaseCompileClasspath"));
+
+  public Set<ResolvedDependency> findResolvedDependencies(Project rootProject) {
+    return rootProject.getAllprojects().stream()
+        .flatMap(project -> project.getConfigurations().stream())
+        .filter(configuration -> CONFIGURATION_NAMES.contains(configuration.getName()))
+        .flatMap(configuration -> configuration.getResolvedConfiguration().getFirstLevelModuleDependencies().stream())
+        .collect(Collectors.toSet());
+  }
 
   public Set<ResolvedArtifact> findResolvedArtifacts(Project project) {
     return project.getConfigurations().stream()

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -18,6 +18,7 @@ package org.sonatype.gradle.plugins.scan.common;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,7 +44,7 @@ public class DependenciesFinder
         .flatMap(project -> project.getConfigurations().stream())
         .filter(configuration -> CONFIGURATION_NAMES.contains(configuration.getName()))
         .flatMap(configuration -> configuration.getResolvedConfiguration().getFirstLevelModuleDependencies().stream())
-        .collect(Collectors.toSet());
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   public Set<ResolvedArtifact> findResolvedArtifacts(Project project) {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -230,7 +230,7 @@ public class OssIndexAuditTask
         .map(child -> logWithVulnerabilities(child, dependenciesMap, response, processedPackageUrls,
             StringUtils.replaceOnce(prefix, DEPENDENCY_PREFIX, "|    ") + DEPENDENCY_PREFIX))
         .collect(Collectors.toList())
-        .contains(true);
+        .contains(true) || hasVulnerabilities;
 
   }
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -20,10 +20,11 @@ import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.sonatype.goodies.packageurl.PackageUrl;
@@ -39,10 +40,10 @@ import org.sonatype.ossindex.service.client.marshal.Marshaller;
 import org.sonatype.ossindex.service.client.transport.Transport;
 import org.sonatype.ossindex.service.client.transport.Transport.TransportException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
-import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting;
@@ -68,13 +69,15 @@ public class OssIndexAuditTask
     boolean hasVulnerabilities;
 
     try (OssindexClient ossIndexClient = buildOssIndexClient()) {
+      Set<ResolvedDependency> dependencies = dependenciesFinder.findResolvedDependencies(getProject());
+      Map<ResolvedDependency, PackageUrl> dependenciesMap = new HashMap<>();
 
-      Map<PackageUrl, ResolvedArtifact> artifactsMap = getProject().getAllprojects().stream()
-          .flatMap(project -> dependenciesFinder.findResolvedArtifacts(project).stream())
-          .collect(Collectors.toMap(this::packageUrl, artifact -> artifact));
+      dependencies.forEach(dependency -> {
+        buildDependenciesMap(dependency, dependenciesMap);
+      });
 
-      List<PackageUrl> packageUrls = new ArrayList<>(artifactsMap.keySet());
-      log.info("Checking vulnerabilities in {} artifacts", packageUrls.size());
+      List<PackageUrl> packageUrls = new ArrayList<>(dependenciesMap.values());
+      log.info("Checking vulnerabilities in {} dependencies", packageUrls.size());
 
       Map<PackageUrl, ComponentReport> response;
 
@@ -85,7 +88,7 @@ public class OssIndexAuditTask
         response = ossIndexClient.requestComponentReports(packageUrls);
       }
 
-      hasVulnerabilities = handleOssIndexResponse(artifactsMap, response);
+      hasVulnerabilities = handleOssIndexResponse(dependencies, dependenciesMap, response);
     }
     catch (TransportException e) {
       throw new GradleException("Connection to OSS Index failed, check your credentials: " + e.getMessage(), e);
@@ -134,50 +137,75 @@ public class OssIndexAuditTask
     return map;
   }
 
+  private void buildDependenciesMap(ResolvedDependency dependency, Map<ResolvedDependency, PackageUrl> mapAccumulator) {
+    mapAccumulator.put(dependency, toPackageUrl(dependency));
+
+    dependency.getChildren().forEach(children -> {
+      mapAccumulator.put(children, toPackageUrl(children));
+      buildDependenciesMap(children, mapAccumulator);
+    });
+  }
+
+  private PackageUrl toPackageUrl(ResolvedDependency dependency) {
+    return new PackageUrlBuilder()
+        .type("maven")
+        .namespace(dependency.getModule().getId().getGroup())
+        .name(dependency.getModule().getId().getName())
+        .version(dependency.getModule().getId().getVersion())
+        .build();
+  }
+
   private boolean handleOssIndexResponse(
-      Map<PackageUrl, ResolvedArtifact> artifactsMap,
+      Set<ResolvedDependency> dependencies,
+      Map<ResolvedDependency, PackageUrl> dependenciesMap,
       Map<PackageUrl, ComponentReport> response)
   {
     boolean hasVulnerabilities = false;
 
-    for (Entry<PackageUrl, ComponentReport> entry : response.entrySet()) {
-      ResolvedArtifact artifact = artifactsMap.get(entry.getKey());
-
-      List<ComponentReportVulnerability> vulnerabilities = entry.getValue().getVulnerabilities();
-
-      StringBuilder vulnerabilitiesText = new StringBuilder(vulnerabilities.size() + " vulnerabilities detected")
-          .append(vulnerabilities.stream()
-              .map(this::handleComponentReportVulnerability)
-              .collect(Collectors.joining(System.lineSeparator())));
-
-      if (vulnerabilities.isEmpty()) {
-        log.info("{}: {}", artifact.getId().getComponentIdentifier().getDisplayName(), vulnerabilitiesText);
-      }
-      else {
-        hasVulnerabilities = true;
-        log.error("{}: {}", artifact.getId().getComponentIdentifier().getDisplayName(), vulnerabilitiesText);
-      }
+    for (ResolvedDependency dependency : dependencies) {
+      hasVulnerabilities = logWithVulnerabilities(dependency, dependenciesMap, response, "|-");
     }
 
     return hasVulnerabilities;
   }
 
-  private PackageUrl packageUrl(ResolvedArtifact artifact) {
-    PackageUrlBuilder builder = new PackageUrlBuilder()
-        .type("maven")
-        .namespace(artifact.getModuleVersion().getId().getGroup())
-        .name(artifact.getModuleVersion().getId().getName())
-        .version(artifact.getModuleVersion().getId().getVersion());
+  private boolean logWithVulnerabilities(
+      ResolvedDependency dependency,
+      Map<ResolvedDependency, PackageUrl> dependenciesMap,
+      Map<PackageUrl, ComponentReport> response,
+      String prefix)
+  {
+    PackageUrl packageUrl = dependenciesMap.get(dependency);
+    ComponentReport report = response.get(packageUrl);
+    List<ComponentReportVulnerability> vulnerabilities =
+        report != null ? report.getVulnerabilities() : Collections.emptyList();
 
-    if (StringUtils.isNotBlank(artifact.getExtension())) {
-      builder.qualifier("extension", artifact.getExtension());
+    StringBuilder vulnerabilitiesText = new StringBuilder()
+        .append(vulnerabilities.size())
+        .append(" vulnerabilities detected")
+        .append(vulnerabilities.stream()
+            .map(vulnerability -> handleComponentReportVulnerability(vulnerability, prefix))
+            .collect(Collectors.joining(System.lineSeparator())));
+
+    ModuleVersionIdentifier id = dependency.getModule().getId();
+
+    if (!vulnerabilities.isEmpty()) {
+      log.info("{}{}:{}:{}: {}", prefix, id.getGroup(), id.getName(), id.getVersion(), vulnerabilitiesText);
+    }
+    else {
+      log.error("{}{}:{}:{}: {}", prefix, id.getGroup(), id.getName(), id.getVersion(), vulnerabilitiesText);
     }
 
-    return builder.build();
+    return dependency.getChildren().stream()
+        .map(children -> logWithVulnerabilities(children, dependenciesMap, response, prefix + "-"))
+        .anyMatch(hasVulnerabilities -> hasVulnerabilities == true);
   }
 
-  private String handleComponentReportVulnerability(ComponentReportVulnerability vulnerability) {
-    StringBuilder builder = new StringBuilder(System.lineSeparator()).append(vulnerability.getTitle());
+  private String handleComponentReportVulnerability(ComponentReportVulnerability vulnerability, String prefix) {
+    StringBuilder builder = new StringBuilder(System.lineSeparator())
+        .append(prefix)
+        .append(">")
+        .append(vulnerability.getTitle());
 
     if (vulnerability.getCvssScore() != null) {
       builder.append(" (").append(vulnerability.getCvssScore()).append(')');

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
@@ -55,7 +55,6 @@ public class OssIndexAuditTaskTest
       .namespace("commons-collections")
       .name("commons-collections")
       .version("3.1")
-      .qualifier("extension", "jar")
       .build();
 
   @Mock


### PR DESCRIPTION
Shows the dependencies and the vulnerabilities found by OSS Index in a tree structure (according to transitive dependencies). This would make the output a lot more readable for projects with a long list of dependencies and / or vulnerabilities found.

## Before this PR:
```
com.google.guava:guava:27.0.1-jre: 0 vulnerabilities detected
commons-logging:commons-logging:1.1.3: 0 vulnerabilities detected
org.slf4j:jul-to-slf4j:1.7.6: 0 vulnerabilities detected
com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava: 0 vulnerabilities detected
ch.qos.logback:logback-core:1.1.1: 1 vulnerabilities detected
[CVE-2017-5929]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/391196a7-f007-430b-b47f-cd9a3fec6374
com.google.guava:failureaccess:1.0.1: 0 vulnerabilities detected
com.fasterxml.jackson.core:jackson-databind:2.3.2: 40 vulnerabilities detected
[CVE-2019-14893] A flaw was discovered in FasterXML jackson-databind in all versions before 2.9.1... (9.8): https://ossindex.sonatype.org/vuln/5113110f-3321-491d-9506-447a3361f9cd

[CVE-2020-11619] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (9.8): https://ossindex.sonatype.org/vuln/5573b207-1a49-45a3-8dbc-71685b0f1012

[CVE-2018-5968]  Incomplete Blacklist, Deserialization of Untrusted Data (8.1): https://ossindex.sonatype.org/vuln/ab9013f0-09a2-4f01-bce5-751dc7437494

[CVE-2018-19361]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/5a041483-5b69-47f8-b8a9-e631830ceaf9

[CVE-2019-17531] A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 th... (9.8): https://ossindex.sonatype.org/vuln/ea932c13-011a-4c74-a092-48cd1c49adb4

[CVE-2020-11111] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/38254502-b22d-424d-a101-6da4433580ee

[CVE-2020-14061] FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction betwee... (8.1): https://ossindex.sonatype.org/vuln/1d118717-b49c-40ba-acd1-4f76dbbb6388

[CVE-2020-9547] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (9.8): https://ossindex.sonatype.org/vuln/9da160f2-eb42-4ae6-af89-509b72c038cc

[CVE-2017-17485]  Improper Control of Generation of Code ("Code Injection") (9.8): https://ossindex.sonatype.org/vuln/b85a00e3-7d9b-49cf-9b19-b73f8ee60275

[CVE-2019-17267] A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2... (9.8): https://ossindex.sonatype.org/vuln/6ce886d0-2dfd-4cef-b9a4-2fb400baf5ef

[CVE-2017-15095]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/1205a1ec-0837-406f-b081-623b9fb02992

[CVE-2018-1000873]  Improper Input Validation (6.5): https://ossindex.sonatype.org/vuln/292c11e9-cf66-4d76-aaf7-b63a091f8891

[CVE-2018-19362]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/5afe3c10-61cc-4ca0-99ae-c6ba8f330b45

[CVE-2020-14062] FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction betwee... (8.1): https://ossindex.sonatype.org/vuln/ec7df330-c447-40b7-8e5b-e8cf9ccaf554

[CVE-2020-9548] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (9.8): https://ossindex.sonatype.org/vuln/f479df7f-a147-4b9a-809d-828667c3d08e

[CVE-2020-14060] FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction betwee... (8.1): https://ossindex.sonatype.org/vuln/8eb39fa0-6815-4460-9fad-5f3595149d8a

[CVE-2018-11307] An issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.5. Use o... (9.8): https://ossindex.sonatype.org/vuln/cc8066c6-7e9c-4f25-b44b-56861eb1673b

[CVE-2020-11112] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/b217e47a-bd88-4936-b953-8560d22683dd

[CVE-2020-11113] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/69934c79-655c-4b0a-971b-ce869a375183

[CVE-2018-19360]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/dc5c85aa-ec0c-42b9-a11b-935184041ee7

[CVE-2019-16943] A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 th... (9.8): https://ossindex.sonatype.org/vuln/f4f0c103-c9d9-4308-bd8f-489f2a632680

[CVE-2018-14721] FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to cond... (10.0): https://ossindex.sonatype.org/vuln/38d99713-5def-4551-bae6-d587e7a69425

[CVE-2020-10968] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/b9dd031f-8287-454b-841f-635120eb35c2

[CVE-2019-20330] FasterXML jackson-databind 2.x before 2.9.10.2 lacks certain net.sf.ehcache bloc... (9.8): https://ossindex.sonatype.org/vuln/40d250b4-680a-4cf2-a677-40b8cdda0ce2

[CVE-2017-7525]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/3f596fc0-9615-4b93-b30a-d4e0532e667f

[CVE-2019-16942] A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 th... (9.8): https://ossindex.sonatype.org/vuln/07632245-fcef-4eb3-82b6-aadbbfd2b33e

[CVE-2018-7489]  Incomplete Blacklist, Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/4f7e98ad-2212-45d3-ac21-089b3b082e6c

CWE-611: Improper Restriction of XML External Entity Reference ('XXE') (5.4): https://ossindex.sonatype.org/vuln/c7abe187-2ea1-4630-882d-c28e71f96db3

[CVE-2020-14195] FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction betwee... (8.1): https://ossindex.sonatype.org/vuln/8a0d6ade-00da-494d-b675-d15fa32b71a6

[CVE-2018-14720]  Improper Restriction of XML External Entity Reference ("XXE") (9.8): https://ossindex.sonatype.org/vuln/91e8cc27-421a-42ba-bd2a-5bede948da1c

[CVE-2020-11620] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (9.8): https://ossindex.sonatype.org/vuln/323c6a23-f1e2-416d-bbcf-77b58cf7d4c4

[CVE-2018-14718]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/af22d349-929c-41ae-ba6c-2f7b507026f0

[CVE-2019-14540] A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2... (9.8): https://ossindex.sonatype.org/vuln/fc1e8802-77e5-458f-b987-eb778c6ac2fc

[CVE-2020-10673] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/ed6fd4f6-b25f-494e-b4e3-ef10deff7d39

[CVE-2020-8840] FasterXML jackson-databind 2.0.0 through 2.9.10.2 lacks certain xbean-reflect/JN... (9.8): https://ossindex.sonatype.org/vuln/2fada372-53aa-4b38-907c-7d3faba7bcb8

[CVE-2020-10672] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/008dd13c-dede-46f4-b103-f72bdbae725e

[CVE-2020-9546] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (9.8): https://ossindex.sonatype.org/vuln/a2779722-6c77-4e1b-8ff0-71df027e1f03

[CVE-2019-16335] A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2... (9.8): https://ossindex.sonatype.org/vuln/3242fdc1-bfe9-46a6-af0c-0b8f57f56eb7

[CVE-2020-10969] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/2fce6452-0901-4591-84ce-be0b9e4e82e9

[CVE-2018-14719]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/b8cc7294-46c2-40df-99de-0a2dd2c6c500
org.springframework:spring-aop:4.0.3.RELEASE: 0 vulnerabilities detected
org.springframework.boot:spring-boot-starter:1.0.0.RELEASE: 0 vulnerabilities detected
org.springframework:spring-beans:4.0.3.RELEASE: 0 vulnerabilities detected
org.apache.commons:commons-math3:3.6.1: 0 vulnerabilities detected
org.codehaus.mojo:animal-sniffer-annotations:1.17: 0 vulnerabilities detected
com.fasterxml.jackson.core:jackson-core:2.3.2: 2 vulnerabilities detected
[CVE-2016-3720] XML external entity (XXE) vulnerability in XmlMapper in the Data format extensio... (9.8): https://ossindex.sonatype.org/vuln/86bfb41b-53e0-4e9f-bda9-73723fb765f1

[CVE-2016-7051]  Improper Restriction of XML External Entity Reference ("XXE"), (8.6): https://ossindex.sonatype.org/vuln/5b39de39-3274-4851-bcc4-035c9759bd9f
org.apache.tomcat.embed:tomcat-embed-logging-juli:7.0.52: 0 vulnerabilities detected
org.springframework.boot:spring-boot-starter-web:1.0.0.RELEASE: 0 vulnerabilities detected
com.google.errorprone:error_prone_annotations:2.2.0: 0 vulnerabilities detected
aopalliance:aopalliance:1.0: 0 vulnerabilities detected
com.fasterxml.jackson.core:jackson-annotations:2.3.0: 0 vulnerabilities detected
org.slf4j:jcl-over-slf4j:1.7.6: 0 vulnerabilities detected
org.slf4j:log4j-over-slf4j:1.7.6: 0 vulnerabilities detected
org.springframework:spring-context:4.0.3.RELEASE: 0 vulnerabilities detected
org.springframework:spring-expression:4.0.3.RELEASE: 0 vulnerabilities detected
org.springframework:spring-web:4.0.3.RELEASE: 3 vulnerabilities detected
[CVE-2015-3192]  Improper Restriction of Operations within the Bounds of a Memory Buffer (5.5): https://ossindex.sonatype.org/vuln/567af0d7-0b7d-40bc-be29-461aa5116f2e

[CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b

[CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
org.slf4j:slf4j-api:1.7.6: 0 vulnerabilities detected
org.springframework.boot:spring-boot:1.0.0.RELEASE: 3 vulnerabilities detected
Spring Expression Language (SpEL) injection on whitelabel error page (0.0): https://ossindex.sonatype.org/vuln/ee7ecdd0-0c27-45f8-a4b6-a288353395eb

Information exposure (classpath files) (0.0): https://ossindex.sonatype.org/vuln/ed611d03-0c61-4d77-896a-12e7d73492ed

Memory exposure (0.0): https://ossindex.sonatype.org/vuln/24c8ed2d-0824-4847-9a56-39eca5a1ffc7
org.apache.tomcat.embed:tomcat-embed-core:7.0.52: 14 vulnerabilities detected
[CVE-2018-1304] The URL pattern of "" (the empty string) which exactly maps to the context root ... (5.9): https://ossindex.sonatype.org/vuln/8f99ba5b-d53a-45a9-b1ab-bae242a45a95

[CVE-2018-1336]  Uncontrolled Resource Consumption ("Resource Exhaustion") (7.5): https://ossindex.sonatype.org/vuln/862c65d0-3dd9-46d2-bbd2-03af4fbbdbf5

[CVE-2016-5388]  Improper Access Control (8.1): https://ossindex.sonatype.org/vuln/befad2de-8388-45c0-86cc-961e4ce03bea

[CVE-2020-1938] When using the Apache JServ Protocol (AJP), care must be taken when trusting inc... (9.8): https://ossindex.sonatype.org/vuln/a08a7b6a-6fc2-48be-9ecd-118be87806cf

[CVE-2020-1745] A file inclusion vulnerability was found in the AJP connector enabled with a def... (7.5): https://ossindex.sonatype.org/vuln/81b13650-cc85-46db-82da-5ff7fb62514c

[CVE-2018-11784]  URL Redirection to Untrusted Site ("Open Redirect") (4.3): https://ossindex.sonatype.org/vuln/e4192d87-019a-4526-abf7-5e7b16b9f974

[CVE-2018-8034] The host name verification when using TLS with the WebSocket client was missing.... (7.5): https://ossindex.sonatype.org/vuln/109b05b7-3271-4d18-b734-1d7f7584f764

[CVE-2020-1935] In Apache Tomcat 9.0.0.M1 to 9.0.30, 8.5.0 to 8.5.50 and 7.0.0 to 7.0.99 the HTT... (4.8): https://ossindex.sonatype.org/vuln/cdb286ae-531f-4a30-90eb-21e059c2232d

[CVE-2019-12418] When Apache Tomcat 9.0.0.M1 to 9.0.28, 8.5.0 to 8.5.47, 7.0.0 and 7.0.97 is conf... (7.0): https://ossindex.sonatype.org/vuln/d26aadb9-d565-4eeb-90eb-76d5fa730cb4

[CVE-2019-17563] When using FORM authentication with Apache Tomcat 9.0.0.M1 to 9.0.29, 8.5.0 to 8... (7.5): https://ossindex.sonatype.org/vuln/560710f9-4912-441c-9aae-3baec60c9964

[CVE-2018-8014] The defaults settings for the CORS filter provided in Apache Tomcat 9.0.0.M1 to ... (9.8): https://ossindex.sonatype.org/vuln/59b4ec0a-0462-480d-8de6-eb3e8d149ea3

[CVE-2020-9484] When using Apache Tomcat versions 10.0.0-M1 to 10.0.0-M4, 9.0.0.M1 to 9.0.34, 8.... (7.0): https://ossindex.sonatype.org/vuln/66e389df-c37c-43aa-9e5e-e6e3ff50ae16

[CVE-2019-0221]  Improper Neutralization of Input During Web Page Generation ("Cross-site Scripting") (6.1): https://ossindex.sonatype.org/vuln/45adc64a-392d-4d7f-8723-9997e4787496

[CVE-2018-1305]  Improper Access Control (6.5): https://ossindex.sonatype.org/vuln/f07dfb64-dd99-4083-a35d-2605e374dd4e
org.springframework.boot:spring-boot-autoconfigure:1.0.0.RELEASE: 3 vulnerabilities detected
Information exposure (classpath files) (0.0): https://ossindex.sonatype.org/vuln/ed611d03-0c61-4d77-896a-12e7d73492ed

Memory exposure (0.0): https://ossindex.sonatype.org/vuln/24c8ed2d-0824-4847-9a56-39eca5a1ffc7

Spring Expression Language (SpEL) injection on whitelabel error page (0.0): https://ossindex.sonatype.org/vuln/ee7ecdd0-0c27-45f8-a4b6-a288353395eb
com.google.code.findbugs:jsr305:3.0.2: 0 vulnerabilities detected
org.springframework.boot:spring-boot-starter-tomcat:1.0.0.RELEASE: 0 vulnerabilities detected
org.springframework:spring-webmvc:4.0.3.RELEASE: 3 vulnerabilities detected
[CVE-2014-3625]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/8e6ea23f-abd8-4067-b501-9cd59be757f4

[CVE-2014-3578]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/2cc56b92-af05-4ccb-ab6c-096c427a89bd

[CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
org.springframework.boot:spring-boot-starter-logging:1.0.0.RELEASE: 0 vulnerabilities detected
org.checkerframework:checker-qual:2.5.2: 0 vulnerabilities detected
org.apache.tomcat.embed:tomcat-embed-el:7.0.52: 1 vulnerabilities detected
[CVE-2014-7810]  Improper Access Control (5.0): https://ossindex.sonatype.org/vuln/568c9598-b5c3-44b7-a573-9bf7fa3dfe8b
com.google.j2objc:j2objc-annotations:1.1: 0 vulnerabilities detected
ch.qos.logback:logback-classic:1.1.1: 1 vulnerabilities detected
[CVE-2017-5929]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/391196a7-f007-430b-b47f-cd9a3fec6374
org.springframework:spring-core:4.0.3.RELEASE: 8 vulnerabilities detected
[CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b

[CVE-2018-1272]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/aa7190e3-4c47-42d6-82f6-afaf1da5762e

[CVE-2016-5007]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/cbdfa2a3-d1f2-4c69-a873-a580c1156437

[CVE-2014-3578]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/2cc56b92-af05-4ccb-ab6c-096c427a89bd

[CVE-2014-3625]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/8e6ea23f-abd8-4067-b501-9cd59be757f4

[CVE-2018-1271]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.9): https://ossindex.sonatype.org/vuln/580d61c3-20df-4bb8-99c3-36c89e0d7550

[CVE-2018-1270]  Improperly Implemented Security Check for Standard (9.8): https://ossindex.sonatype.org/vuln/9a3de118-b038-49ed-9af7-533210c9d85f

[CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
```

## With this PR:
```
+--- org.apache.commons:commons-math3:3.6.1: 0 vulnerabilities detected
+--- com.google.guava:guava:27.0.1-jre: 0 vulnerabilities detected
|    +--- com.google.code.findbugs:jsr305:3.0.2: 0 vulnerabilities detected
|    +--- com.google.errorprone:error_prone_annotations:2.2.0: 0 vulnerabilities detected
|    +--- com.google.guava:failureaccess:1.0.1: 0 vulnerabilities detected
|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava: 0 vulnerabilities detected
|    +--- com.google.j2objc:j2objc-annotations:1.1: 0 vulnerabilities detected
|    +--- org.checkerframework:checker-qual:2.5.2: 0 vulnerabilities detected
|    +--- org.codehaus.mojo:animal-sniffer-annotations:1.17: 0 vulnerabilities detected
+--- org.springframework.boot:spring-boot-starter-web:1.0.0.RELEASE: 0 vulnerabilities detected
|    +--- com.fasterxml.jackson.core:jackson-databind:2.3.2: 40 vulnerabilities detected
|         [CVE-2019-14893] A flaw was discovered in FasterXML jackson-databind in all versions before 2.9.1... (9.8): https://ossindex.sonatype.org/vuln/5113110f-3321-491d-9506-447a3361f9cd
|         [CVE-2020-11619] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (9.8): https://ossindex.sonatype.org/vuln/5573b207-1a49-45a3-8dbc-71685b0f1012
|         [CVE-2018-5968]  Incomplete Blacklist, Deserialization of Untrusted Data (8.1): https://ossindex.sonatype.org/vuln/ab9013f0-09a2-4f01-bce5-751dc7437494
|         [CVE-2018-19361]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/5a041483-5b69-47f8-b8a9-e631830ceaf9
|         [CVE-2019-17531] A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 th... (9.8): https://ossindex.sonatype.org/vuln/ea932c13-011a-4c74-a092-48cd1c49adb4
|         [CVE-2020-11111] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/38254502-b22d-424d-a101-6da4433580ee
|         [CVE-2020-14061] FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction betwee... (8.1): https://ossindex.sonatype.org/vuln/1d118717-b49c-40ba-acd1-4f76dbbb6388
|         [CVE-2020-9547] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (9.8): https://ossindex.sonatype.org/vuln/9da160f2-eb42-4ae6-af89-509b72c038cc
|         [CVE-2017-17485]  Improper Control of Generation of Code ("Code Injection") (9.8): https://ossindex.sonatype.org/vuln/b85a00e3-7d9b-49cf-9b19-b73f8ee60275
|         [CVE-2019-17267] A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2... (9.8): https://ossindex.sonatype.org/vuln/6ce886d0-2dfd-4cef-b9a4-2fb400baf5ef
|         [CVE-2017-15095]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/1205a1ec-0837-406f-b081-623b9fb02992
|         [CVE-2018-1000873]  Improper Input Validation (6.5): https://ossindex.sonatype.org/vuln/292c11e9-cf66-4d76-aaf7-b63a091f8891
|         [CVE-2018-19362]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/5afe3c10-61cc-4ca0-99ae-c6ba8f330b45
|         [CVE-2020-14062] FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction betwee... (8.1): https://ossindex.sonatype.org/vuln/ec7df330-c447-40b7-8e5b-e8cf9ccaf554
|         [CVE-2020-9548] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (9.8): https://ossindex.sonatype.org/vuln/f479df7f-a147-4b9a-809d-828667c3d08e
|         [CVE-2020-14060] FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction betwee... (8.1): https://ossindex.sonatype.org/vuln/8eb39fa0-6815-4460-9fad-5f3595149d8a
|         [CVE-2018-11307] An issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.5. Use o... (9.8): https://ossindex.sonatype.org/vuln/cc8066c6-7e9c-4f25-b44b-56861eb1673b
|         [CVE-2020-11112] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/b217e47a-bd88-4936-b953-8560d22683dd
|         [CVE-2020-11113] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/69934c79-655c-4b0a-971b-ce869a375183
|         [CVE-2018-19360]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/dc5c85aa-ec0c-42b9-a11b-935184041ee7
|         [CVE-2019-16943] A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 th... (9.8): https://ossindex.sonatype.org/vuln/f4f0c103-c9d9-4308-bd8f-489f2a632680
|         [CVE-2018-14721] FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to cond... (10.0): https://ossindex.sonatype.org/vuln/38d99713-5def-4551-bae6-d587e7a69425
|         [CVE-2020-10968] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/b9dd031f-8287-454b-841f-635120eb35c2
|         [CVE-2019-20330] FasterXML jackson-databind 2.x before 2.9.10.2 lacks certain net.sf.ehcache bloc... (9.8): https://ossindex.sonatype.org/vuln/40d250b4-680a-4cf2-a677-40b8cdda0ce2
|         [CVE-2017-7525]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/3f596fc0-9615-4b93-b30a-d4e0532e667f
|         [CVE-2019-16942] A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 th... (9.8): https://ossindex.sonatype.org/vuln/07632245-fcef-4eb3-82b6-aadbbfd2b33e
|         [CVE-2018-7489]  Incomplete Blacklist, Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/4f7e98ad-2212-45d3-ac21-089b3b082e6c
|         CWE-611: Improper Restriction of XML External Entity Reference ('XXE') (5.4): https://ossindex.sonatype.org/vuln/c7abe187-2ea1-4630-882d-c28e71f96db3
|         [CVE-2020-14195] FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction betwee... (8.1): https://ossindex.sonatype.org/vuln/8a0d6ade-00da-494d-b675-d15fa32b71a6
|         [CVE-2018-14720]  Improper Restriction of XML External Entity Reference ("XXE") (9.8): https://ossindex.sonatype.org/vuln/91e8cc27-421a-42ba-bd2a-5bede948da1c
|         [CVE-2020-11620] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (9.8): https://ossindex.sonatype.org/vuln/323c6a23-f1e2-416d-bbcf-77b58cf7d4c4
|         [CVE-2018-14718]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/af22d349-929c-41ae-ba6c-2f7b507026f0
|         [CVE-2019-14540] A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2... (9.8): https://ossindex.sonatype.org/vuln/fc1e8802-77e5-458f-b987-eb778c6ac2fc
|         [CVE-2020-10673] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/ed6fd4f6-b25f-494e-b4e3-ef10deff7d39
|         [CVE-2020-8840] FasterXML jackson-databind 2.0.0 through 2.9.10.2 lacks certain xbean-reflect/JN... (9.8): https://ossindex.sonatype.org/vuln/2fada372-53aa-4b38-907c-7d3faba7bcb8
|         [CVE-2020-10672] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/008dd13c-dede-46f4-b103-f72bdbae725e
|         [CVE-2020-9546] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (9.8): https://ossindex.sonatype.org/vuln/a2779722-6c77-4e1b-8ff0-71df027e1f03
|         [CVE-2019-16335] A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2... (9.8): https://ossindex.sonatype.org/vuln/3242fdc1-bfe9-46a6-af0c-0b8f57f56eb7
|         [CVE-2020-10969] FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction betwee... (8.8): https://ossindex.sonatype.org/vuln/2fce6452-0901-4591-84ce-be0b9e4e82e9
|         [CVE-2018-14719]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/b8cc7294-46c2-40df-99de-0a2dd2c6c500
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.3.0: 0 vulnerabilities detected
|    |    +--- com.fasterxml.jackson.core:jackson-core:2.3.2: 2 vulnerabilities detected
|    |         [CVE-2016-3720] XML external entity (XXE) vulnerability in XmlMapper in the Data format extensio... (9.8): https://ossindex.sonatype.org/vuln/86bfb41b-53e0-4e9f-bda9-73723fb765f1
|    |         [CVE-2016-7051]  Improper Restriction of XML External Entity Reference ("XXE"), (8.6): https://ossindex.sonatype.org/vuln/5b39de39-3274-4851-bcc4-035c9759bd9f
|    +--- org.springframework:spring-web:4.0.3.RELEASE: 3 vulnerabilities detected
|         [CVE-2015-3192]  Improper Restriction of Operations within the Bounds of a Memory Buffer (5.5): https://ossindex.sonatype.org/vuln/567af0d7-0b7d-40bc-be29-461aa5116f2e
|         [CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
|         [CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
|    |    +--- org.springframework:spring-aop:4.0.3.RELEASE: 0 vulnerabilities detected
|    |    |    +--- aopalliance:aopalliance:1.0: 0 vulnerabilities detected
|    |    |    +--- org.springframework:spring-beans:4.0.3.RELEASE: 0 vulnerabilities detected
|    |    |    |    +--- org.springframework:spring-core:4.0.3.RELEASE: 8 vulnerabilities detected
|    |    |    |         [CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
|    |    |    |         [CVE-2018-1272]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/aa7190e3-4c47-42d6-82f6-afaf1da5762e
|    |    |    |         [CVE-2016-5007]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/cbdfa2a3-d1f2-4c69-a873-a580c1156437
|    |    |    |         [CVE-2014-3578]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/2cc56b92-af05-4ccb-ab6c-096c427a89bd
|    |    |    |         [CVE-2014-3625]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/8e6ea23f-abd8-4067-b501-9cd59be757f4
|    |    |    |         [CVE-2018-1271]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.9): https://ossindex.sonatype.org/vuln/580d61c3-20df-4bb8-99c3-36c89e0d7550
|    |    |    |         [CVE-2018-1270]  Improperly Implemented Security Check for Standard (9.8): https://ossindex.sonatype.org/vuln/9a3de118-b038-49ed-9af7-533210c9d85f
|    |    |    |         [CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
|    |    |    |    |    +--- commons-logging:commons-logging:1.1.3: 0 vulnerabilities detected
|    |    |    +--- org.springframework:spring-core:4.0.3.RELEASE (*): 8 vulnerabilities detected
|    |    |         [CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
|    |    |         [CVE-2018-1272]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/aa7190e3-4c47-42d6-82f6-afaf1da5762e
|    |    |         [CVE-2016-5007]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/cbdfa2a3-d1f2-4c69-a873-a580c1156437
|    |    |         [CVE-2014-3578]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/2cc56b92-af05-4ccb-ab6c-096c427a89bd
|    |    |         [CVE-2014-3625]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/8e6ea23f-abd8-4067-b501-9cd59be757f4
|    |    |         [CVE-2018-1271]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.9): https://ossindex.sonatype.org/vuln/580d61c3-20df-4bb8-99c3-36c89e0d7550
|    |    |         [CVE-2018-1270]  Improperly Implemented Security Check for Standard (9.8): https://ossindex.sonatype.org/vuln/9a3de118-b038-49ed-9af7-533210c9d85f
|    |    |         [CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
|    |    +--- org.springframework:spring-beans:4.0.3.RELEASE (*): 0 vulnerabilities detected
|    |    +--- org.springframework:spring-context:4.0.3.RELEASE: 0 vulnerabilities detected
|    |    |    +--- org.springframework:spring-aop:4.0.3.RELEASE (*): 0 vulnerabilities detected
|    |    |    +--- org.springframework:spring-beans:4.0.3.RELEASE (*): 0 vulnerabilities detected
|    |    |    +--- org.springframework:spring-core:4.0.3.RELEASE (*): 8 vulnerabilities detected
|    |    |         [CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
|    |    |         [CVE-2018-1272]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/aa7190e3-4c47-42d6-82f6-afaf1da5762e
|    |    |         [CVE-2016-5007]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/cbdfa2a3-d1f2-4c69-a873-a580c1156437
|    |    |         [CVE-2014-3578]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/2cc56b92-af05-4ccb-ab6c-096c427a89bd
|    |    |         [CVE-2014-3625]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/8e6ea23f-abd8-4067-b501-9cd59be757f4
|    |    |         [CVE-2018-1271]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.9): https://ossindex.sonatype.org/vuln/580d61c3-20df-4bb8-99c3-36c89e0d7550
|    |    |         [CVE-2018-1270]  Improperly Implemented Security Check for Standard (9.8): https://ossindex.sonatype.org/vuln/9a3de118-b038-49ed-9af7-533210c9d85f
|    |    |         [CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
|    |    |    +--- org.springframework:spring-expression:4.0.3.RELEASE: 0 vulnerabilities detected
|    |    |    |    +--- org.springframework:spring-core:4.0.3.RELEASE (*): 8 vulnerabilities detected
|    |    |    |         [CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
|    |    |    |         [CVE-2018-1272]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/aa7190e3-4c47-42d6-82f6-afaf1da5762e
|    |    |    |         [CVE-2016-5007]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/cbdfa2a3-d1f2-4c69-a873-a580c1156437
|    |    |    |         [CVE-2014-3578]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/2cc56b92-af05-4ccb-ab6c-096c427a89bd
|    |    |    |         [CVE-2014-3625]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/8e6ea23f-abd8-4067-b501-9cd59be757f4
|    |    |    |         [CVE-2018-1271]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.9): https://ossindex.sonatype.org/vuln/580d61c3-20df-4bb8-99c3-36c89e0d7550
|    |    |    |         [CVE-2018-1270]  Improperly Implemented Security Check for Standard (9.8): https://ossindex.sonatype.org/vuln/9a3de118-b038-49ed-9af7-533210c9d85f
|    |    |    |         [CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
|    |    +--- org.springframework:spring-core:4.0.3.RELEASE (*): 8 vulnerabilities detected
|    |         [CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
|    |         [CVE-2018-1272]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/aa7190e3-4c47-42d6-82f6-afaf1da5762e
|    |         [CVE-2016-5007]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/cbdfa2a3-d1f2-4c69-a873-a580c1156437
|    |         [CVE-2014-3578]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/2cc56b92-af05-4ccb-ab6c-096c427a89bd
|    |         [CVE-2014-3625]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/8e6ea23f-abd8-4067-b501-9cd59be757f4
|    |         [CVE-2018-1271]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.9): https://ossindex.sonatype.org/vuln/580d61c3-20df-4bb8-99c3-36c89e0d7550
|    |         [CVE-2018-1270]  Improperly Implemented Security Check for Standard (9.8): https://ossindex.sonatype.org/vuln/9a3de118-b038-49ed-9af7-533210c9d85f
|    |         [CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
|    +--- org.springframework:spring-webmvc:4.0.3.RELEASE: 3 vulnerabilities detected
|         [CVE-2014-3625]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/8e6ea23f-abd8-4067-b501-9cd59be757f4
|         [CVE-2014-3578]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/2cc56b92-af05-4ccb-ab6c-096c427a89bd
|         [CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
|    |    +--- org.springframework:spring-beans:4.0.3.RELEASE (*): 0 vulnerabilities detected
|    |    +--- org.springframework:spring-context:4.0.3.RELEASE (*): 0 vulnerabilities detected
|    |    +--- org.springframework:spring-core:4.0.3.RELEASE (*): 8 vulnerabilities detected
|    |         [CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
|    |         [CVE-2018-1272]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/aa7190e3-4c47-42d6-82f6-afaf1da5762e
|    |         [CVE-2016-5007]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/cbdfa2a3-d1f2-4c69-a873-a580c1156437
|    |         [CVE-2014-3578]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/2cc56b92-af05-4ccb-ab6c-096c427a89bd
|    |         [CVE-2014-3625]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/8e6ea23f-abd8-4067-b501-9cd59be757f4
|    |         [CVE-2018-1271]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.9): https://ossindex.sonatype.org/vuln/580d61c3-20df-4bb8-99c3-36c89e0d7550
|    |         [CVE-2018-1270]  Improperly Implemented Security Check for Standard (9.8): https://ossindex.sonatype.org/vuln/9a3de118-b038-49ed-9af7-533210c9d85f
|    |         [CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
|    |    +--- org.springframework:spring-expression:4.0.3.RELEASE (*): 0 vulnerabilities detected
|    |    +--- org.springframework:spring-web:4.0.3.RELEASE (*): 3 vulnerabilities detected
|    |         [CVE-2015-3192]  Improper Restriction of Operations within the Bounds of a Memory Buffer (5.5): https://ossindex.sonatype.org/vuln/567af0d7-0b7d-40bc-be29-461aa5116f2e
|    |         [CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
|    |         [CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
|    +--- org.springframework.boot:spring-boot-starter:1.0.0.RELEASE: 0 vulnerabilities detected
|    |    +--- org.springframework.boot:spring-boot:1.0.0.RELEASE: 3 vulnerabilities detected
|    |         Spring Expression Language (SpEL) injection on whitelabel error page (0.0): https://ossindex.sonatype.org/vuln/ee7ecdd0-0c27-45f8-a4b6-a288353395eb
|    |         Information exposure (classpath files) (0.0): https://ossindex.sonatype.org/vuln/ed611d03-0c61-4d77-896a-12e7d73492ed
|    |         Memory exposure (0.0): https://ossindex.sonatype.org/vuln/24c8ed2d-0824-4847-9a56-39eca5a1ffc7
|    |    |    +--- org.springframework:spring-context:4.0.3.RELEASE (*): 0 vulnerabilities detected
|    |    |    +--- org.springframework:spring-core:4.0.3.RELEASE (*): 8 vulnerabilities detected
|    |    |         [CVE-2015-5211]  Improper Input Validation (8.6): https://ossindex.sonatype.org/vuln/5c31df94-6945-4798-8b6c-b807dba2712b
|    |    |         [CVE-2018-1272]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/aa7190e3-4c47-42d6-82f6-afaf1da5762e
|    |    |         [CVE-2016-5007]  Permissions, Privileges, and Access Controls (7.5): https://ossindex.sonatype.org/vuln/cbdfa2a3-d1f2-4c69-a873-a580c1156437
|    |    |         [CVE-2014-3578]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/2cc56b92-af05-4ccb-ab6c-096c427a89bd
|    |    |         [CVE-2014-3625]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.0): https://ossindex.sonatype.org/vuln/8e6ea23f-abd8-4067-b501-9cd59be757f4
|    |    |         [CVE-2018-1271]  Improper Limitation of a Pathname to a Restricted Directory ("Path Traversal") (5.9): https://ossindex.sonatype.org/vuln/580d61c3-20df-4bb8-99c3-36c89e0d7550
|    |    |         [CVE-2018-1270]  Improperly Implemented Security Check for Standard (9.8): https://ossindex.sonatype.org/vuln/9a3de118-b038-49ed-9af7-533210c9d85f
|    |    |         [CVE-2014-0225]  Improper Restriction of XML External Entity Reference ("XXE") (8.8): https://ossindex.sonatype.org/vuln/574d289f-b344-4510-a089-9473d2c6118c
|    |    +--- org.springframework.boot:spring-boot-autoconfigure:1.0.0.RELEASE: 3 vulnerabilities detected
|    |         Information exposure (classpath files) (0.0): https://ossindex.sonatype.org/vuln/ed611d03-0c61-4d77-896a-12e7d73492ed
|    |         Memory exposure (0.0): https://ossindex.sonatype.org/vuln/24c8ed2d-0824-4847-9a56-39eca5a1ffc7
|    |         Spring Expression Language (SpEL) injection on whitelabel error page (0.0): https://ossindex.sonatype.org/vuln/ee7ecdd0-0c27-45f8-a4b6-a288353395eb
|    |    |    +--- org.springframework.boot:spring-boot:1.0.0.RELEASE (*): 3 vulnerabilities detected
|    |    |         Spring Expression Language (SpEL) injection on whitelabel error page (0.0): https://ossindex.sonatype.org/vuln/ee7ecdd0-0c27-45f8-a4b6-a288353395eb
|    |    |         Information exposure (classpath files) (0.0): https://ossindex.sonatype.org/vuln/ed611d03-0c61-4d77-896a-12e7d73492ed
|    |    |         Memory exposure (0.0): https://ossindex.sonatype.org/vuln/24c8ed2d-0824-4847-9a56-39eca5a1ffc7
|    |    +--- org.springframework.boot:spring-boot-starter-logging:1.0.0.RELEASE: 0 vulnerabilities detected
|    |    |    +--- ch.qos.logback:logback-classic:1.1.1: 1 vulnerabilities detected
|    |    |         [CVE-2017-5929]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/391196a7-f007-430b-b47f-cd9a3fec6374
|    |    |    |    +--- ch.qos.logback:logback-core:1.1.1: 1 vulnerabilities detected
|    |    |    |         [CVE-2017-5929]  Deserialization of Untrusted Data (9.8): https://ossindex.sonatype.org/vuln/391196a7-f007-430b-b47f-cd9a3fec6374
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.6: 0 vulnerabilities detected
|    |    |    +--- org.slf4j:jcl-over-slf4j:1.7.6: 0 vulnerabilities detected
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.6: 0 vulnerabilities detected
|    |    |    +--- org.slf4j:jul-to-slf4j:1.7.6: 0 vulnerabilities detected
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.6: 0 vulnerabilities detected
|    |    |    +--- org.slf4j:log4j-over-slf4j:1.7.6: 0 vulnerabilities detected
|    |    |    |    +--- org.slf4j:slf4j-api:1.7.6: 0 vulnerabilities detected
|    +--- org.springframework.boot:spring-boot-starter-tomcat:1.0.0.RELEASE: 0 vulnerabilities detected
|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:7.0.52: 14 vulnerabilities detected
|    |         [CVE-2018-1304] The URL pattern of "" (the empty string) which exactly maps to the context root ... (5.9): https://ossindex.sonatype.org/vuln/8f99ba5b-d53a-45a9-b1ab-bae242a45a95
|    |         [CVE-2018-1336]  Uncontrolled Resource Consumption ("Resource Exhaustion") (7.5): https://ossindex.sonatype.org/vuln/862c65d0-3dd9-46d2-bbd2-03af4fbbdbf5
|    |         [CVE-2016-5388]  Improper Access Control (8.1): https://ossindex.sonatype.org/vuln/befad2de-8388-45c0-86cc-961e4ce03bea
|    |         [CVE-2020-1938] When using the Apache JServ Protocol (AJP), care must be taken when trusting inc... (9.8): https://ossindex.sonatype.org/vuln/a08a7b6a-6fc2-48be-9ecd-118be87806cf
|    |         [CVE-2020-1745] A file inclusion vulnerability was found in the AJP connector enabled with a def... (7.5): https://ossindex.sonatype.org/vuln/81b13650-cc85-46db-82da-5ff7fb62514c
|    |         [CVE-2018-11784]  URL Redirection to Untrusted Site ("Open Redirect") (4.3): https://ossindex.sonatype.org/vuln/e4192d87-019a-4526-abf7-5e7b16b9f974
|    |         [CVE-2018-8034] The host name verification when using TLS with the WebSocket client was missing.... (7.5): https://ossindex.sonatype.org/vuln/109b05b7-3271-4d18-b734-1d7f7584f764
|    |         [CVE-2020-1935] In Apache Tomcat 9.0.0.M1 to 9.0.30, 8.5.0 to 8.5.50 and 7.0.0 to 7.0.99 the HTT... (4.8): https://ossindex.sonatype.org/vuln/cdb286ae-531f-4a30-90eb-21e059c2232d
|    |         [CVE-2019-12418] When Apache Tomcat 9.0.0.M1 to 9.0.28, 8.5.0 to 8.5.47, 7.0.0 and 7.0.97 is conf... (7.0): https://ossindex.sonatype.org/vuln/d26aadb9-d565-4eeb-90eb-76d5fa730cb4
|    |         [CVE-2019-17563] When using FORM authentication with Apache Tomcat 9.0.0.M1 to 9.0.29, 8.5.0 to 8... (7.5): https://ossindex.sonatype.org/vuln/560710f9-4912-441c-9aae-3baec60c9964
|    |         [CVE-2018-8014] The defaults settings for the CORS filter provided in Apache Tomcat 9.0.0.M1 to ... (9.8): https://ossindex.sonatype.org/vuln/59b4ec0a-0462-480d-8de6-eb3e8d149ea3
|    |         [CVE-2020-9484] When using Apache Tomcat versions 10.0.0-M1 to 10.0.0-M4, 9.0.0.M1 to 9.0.34, 8.... (7.0): https://ossindex.sonatype.org/vuln/66e389df-c37c-43aa-9e5e-e6e3ff50ae16
|    |         [CVE-2019-0221]  Improper Neutralization of Input During Web Page Generation ("Cross-site Scripting") (6.1): https://ossindex.sonatype.org/vuln/45adc64a-392d-4d7f-8723-9997e4787496
|    |         [CVE-2018-1305]  Improper Access Control (6.5): https://ossindex.sonatype.org/vuln/f07dfb64-dd99-4083-a35d-2605e374dd4e
|    |    +--- org.apache.tomcat.embed:tomcat-embed-el:7.0.52: 1 vulnerabilities detected
|    |         [CVE-2014-7810]  Improper Access Control (5.0): https://ossindex.sonatype.org/vuln/568c9598-b5c3-44b7-a573-9bf7fa3dfe8b
|    |    +--- org.apache.tomcat.embed:tomcat-embed-logging-juli:7.0.52: 0 vulnerabilities detected
```

It relates to the following issue #s:
* Fixes #33 

cc @bhamail / @DarthHater / @guillermo-varela
