### PR TITLE
Clarifies the required user role to use IQ Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ossIndexAudit {
 - Configure IQ Server settings inside the `nexusIQScan` configuration on the file `build.gradle` e.g.
 ```
 nexusIQScan {
-    username = 'admin'
+    username = 'admin' // Make sure to use an user with the role 'Application Evaluator' in the given IQ Server application
     password = 'pass'
     serverUrl = 'http://localhost:8070'
     applicationId = 'app'

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
@@ -87,8 +87,10 @@ public class NexusIqScanTask
         iqClient.validateServerVersion(MINIMAL_SERVER_VERSION_REQUIRED);
 
         if (!iqClient.verifyOrCreateApplication(extension.getApplicationId())) {
-          throw new IllegalArgumentException(
-              String.format("Application ID %s doesn't exist and couldn't be created", extension.getApplicationId()));
+          throw new IllegalArgumentException(String.format(
+              "Application ID %s doesn't exist and couldn't be created or the user %s doesn't have the "
+                  + "'Application Evaluator' role for that application.",
+              extension.getApplicationId(), extension.getUsername()));
         }
 
         ProprietaryConfig proprietaryConfig =

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/ScanTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/ScanTaskTest.java
@@ -109,7 +109,8 @@ public class ScanTaskTest
 
     assertThatThrownBy(() -> task.scan())
         .isInstanceOf(GradleException.class)
-        .hasMessageContaining("Application ID test doesn't exist and couldn't be created");
+        .hasMessageContaining("Application ID test doesn't exist and couldn't be created or the user user doesn't have"
+            + " the 'Application Evaluator' role for that application.");
   }
 
   private NexusIqScanTask buildScanTask(boolean isSimulated) {


### PR DESCRIPTION
Specifies in docs and on error logs that an IQ Server user requires the role 'Application Evaluator' to scan and evaluate the dependencies.

It relates to the following issue #s:
* Fixes #37 