### PR TITLE
Bug Fix -  Identifying vulnerabilities 

### DIFF
--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -178,8 +178,11 @@ public class OssIndexAuditTask
 
     Set<PackageUrl> processedPackageUrls = new HashSet<>();
     for (ResolvedDependency dependency : dependencies) {
-      hasVulnerabilities =
+      boolean vulnerable =
           logWithVulnerabilities(dependency, dependenciesMap, response, processedPackageUrls, DEPENDENCY_PREFIX);
+      if (vulnerable) {
+        hasVulnerabilities = true;
+      }
     }
 
     if (!dependencies.isEmpty()) {


### PR DESCRIPTION
I believe there's a bug with the `ossIndexAudit` task. Particularly when failing a build (due to dependencies have vulnerabilities).  Currently we update the `hasVulnerabilities` flag after evaluating each dependency. So if we have 3 dependencies where the first 2 contain vulnerabilities, as long as the last is safe we won't fail the build. See example below.

So with the following dependencies
```
dependencies {
    implementation "com.google.guava:guava:27.0.1-jre" // vulnerable
    implementation "org.springframework.boot:spring-boot-starter-web:1.0.0.RELEASE" // vulnerable
    implementation "org.apache.commons:commons-math3:3.6.1" // has no vulnerabilities
}
```

**Before PR**
First two dependencies contain vulnerabilities but the build is successful!!!
![image](https://user-images.githubusercontent.com/38332365/92100901-4550e300-edd4-11ea-837e-46f21faea914.png)

**With PR**
Build is correctly failed.
![image](https://user-images.githubusercontent.com/38332365/92100984-61ed1b00-edd4-11ea-9957-3a12bf489b2f.png)

cc @bhamail / @DarthHater / @guillermo-varela
