### PR TITLE
Find dependencies when using Gradle/Android variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Gradle can be used to build projects developed in various programming languages.
 - Edit its `build.gradle` file adding this:
 ```
 plugins {
-  id 'org.sonatype.gradle.plugins.scan' version '1.2.0' // Update the version as needed
+  id 'org.sonatype.gradle.plugins.scan' version '1.2.3' // Update the version as needed
 }
 ```
 
@@ -142,6 +142,21 @@ As mentioned above the values can be set on command line using -D arguments or i
 ### Multi-module projects
 Just apply the plugin on the root project and all sub-modules will be processed and the output will be a single report
 with all components found in each module. This includes Android projects.
+
+### Known issue with dependencies and build variants (mostly found in Android projects)
+Let's say an Android project has a module `core` with some code (library) and another module `app` as the actual Android
+app. When using build variants an error like this may show:
+
+> Could not resolve all dependencies for configuration ':app:releaseCompileClasspath'.
+More than one variant of project :core matches the consumer attributes
+      Configuration ':core:releaseApiElements' variant android-aidl: Unmatched attributes:
+      - Found artifactType 'android-aidl' but wasn't required.
+      - Found com.android.build.api.attributes.VariantAttr 'release' but wasn't required.
+
+At the moment, to get ride of that variant issue we recommend to change the way the library is declared in `app` by
+going to the `build.gradle` file from:
+    - `api project(':core')` or `implementation project(':core')` to
+    - `api project(path: ':core', configuration: 'default')` or `implementation project(path: ':core', configuration: 'default')`
 
 ## Contributing
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ group=org.sonatype.gradle.plugins
 version=1.2.3-SNAPSHOT
 release.useAutomaticVersion=true
 
-nexusJavaApiVersion=3.12
+nexusJavaApiVersion=3.17
 ossIndexClientVersion=1.3.0
 
 junitVersion=4.13

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -37,8 +37,10 @@ import static org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_
 
 public class DependenciesFinder
 {
+  private static final String RELEASE_COMPILE_CONFIGURATION_NAME = "releaseCompileClasspath";
+
   private static final Set<String> CONFIGURATION_NAMES =
-      new HashSet<>(Arrays.asList(COMPILE_CLASSPATH_CONFIGURATION_NAME, "releaseCompileClasspath"));
+      new HashSet<>(Arrays.asList(COMPILE_CLASSPATH_CONFIGURATION_NAME, RELEASE_COMPILE_CONFIGURATION_NAME));
 
   public Set<ResolvedDependency> findResolvedDependencies(Project rootProject, boolean allConfigurations) {
     return rootProject.getAllprojects().stream()
@@ -99,6 +101,7 @@ public class DependenciesFinder
     if (allConfigurations) {
       return configuration.isCanBeResolved();
     }
-    return CONFIGURATION_NAMES.contains(configuration.getName());
+    return CONFIGURATION_NAMES.contains(configuration.getName())
+        || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_COMPILE_CONFIGURATION_NAME);
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
@@ -75,7 +75,8 @@ public class NexusIqScanTask
               Collections.singletonList(new Action(extension.getSimulatedPolicyActionId()))));
         }
 
-        applicationPolicyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, alerts, "simulated/report");
+        applicationPolicyEvaluation =
+            new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, alerts, "simulated/report");
       }
       else {
         InternalIqClient iqClient = InternalIqClientBuilder.create()

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -59,6 +59,13 @@ public class DependenciesFinderTest
   }
 
   @Test
+  public void testFindResolvedDependencies_includeAndroidDependenciesUsingVariant() {
+    Project project = buildProject("variantProdReleaseCompileClasspath", true);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
   public void testFindResolvedDependencies_omitTestDependencies() {
     Project project = buildProject(TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
     Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/ScanTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/ScanTaskTest.java
@@ -69,7 +69,8 @@ public class ScanTaskTest
     when(InternalIqClientBuilder.create()).thenReturn(builderMock);
 
     when(iqClientMock.evaluateApplication(anyString(), anyString(), nullable(ScanResult.class), any(File.class)))
-        .thenReturn(new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, Collections.emptyList(), "simulated/report"));
+        .thenReturn(
+            new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, Collections.emptyList(), "simulated/report"));
     when(builderMock.build()).thenReturn(iqClientMock);
 
     when(dependenciesFinderMock.findModules(any(Project.class), eq(false))).thenReturn(Collections.emptyList());


### PR DESCRIPTION
When using variants the configuration `releaseCompileClasspath` becomes `<variantName>ReleaseCompileClasspath`. This PR makes possible to find dependencies in such Gradle configurations.

It relates to the following issue #s:
* Fixes #30 #31 