### PR TITLE
Fix typo in property and update readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ossIndexAudit {
     useCache = true // true by default
     cacheDirectory = 'some/path' // by default it uses the user data directory (according to OS)
     cacheExpiration = 'PT12H' // 12 hours if omitted. It must follow the Joda Time specification at https://www.javadoc.io/doc/joda-time/joda-time/2.10.4/org/joda/time/Duration.html#parse-java.lang.String-
-    colorEnabled = false // if true prints vulnerability description in color (red). By default is true.  
+    colorEnabled = false // if true prints vulnerability description in color. By default is true.  
 }
 ```
 - Open Terminal on the project's root and run `./gradlew ossIndexAudit`

--- a/src/integTest/resources/legacy-syntax/policy-fail.gradle
+++ b/src/integTest/resources/legacy-syntax/policy-fail.gradle
@@ -21,5 +21,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  simulatedVulnerabityFound = true
+  simulatedVulnerabilityFound = true
 }

--- a/src/integTest/resources/policy-fail.gradle
+++ b/src/integTest/resources/policy-fail.gradle
@@ -21,5 +21,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  simulatedVulnerabityFound = true
+  simulatedVulnerabilityFound = true
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -134,7 +134,7 @@ public class OssIndexAuditTask
       ComponentReport report = new ComponentReport();
       report.setCoordinates(packageUrl);
 
-      if (extension.isSimulatedVulnerabityFound()) {
+      if (extension.isSimulatedVulnerabilityFound()) {
         ComponentReportVulnerability vulnerability = new ComponentReportVulnerability();
         vulnerability.setTitle("Simulated");
         vulnerability.setCvssScore(4f);

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -38,7 +38,7 @@ public class OssIndexPluginExtension
 
   private boolean simulationEnabled;
 
-  private boolean simulatedVulnerabityFound;
+  private boolean simulatedVulnerabilityFound;
 
   private boolean colorEnabled;
 
@@ -49,7 +49,7 @@ public class OssIndexPluginExtension
     cacheDirectory = "";
     cacheExpiration = "";
     simulationEnabled = false;
-    simulatedVulnerabityFound = false;
+    simulatedVulnerabilityFound = false;
     colorEnabled = true;
   }
 
@@ -109,12 +109,12 @@ public class OssIndexPluginExtension
     this.simulationEnabled = simulationEnabled;
   }
 
-  public boolean isSimulatedVulnerabityFound() {
-    return simulatedVulnerabityFound;
+  public boolean isSimulatedVulnerabilityFound() {
+    return simulatedVulnerabilityFound;
   }
 
-  public void setSimulatedVulnerabityFound(boolean simulatedVulnerabityFound) {
-    this.simulatedVulnerabityFound = simulatedVulnerabityFound;
+  public void setSimulatedVulnerabilityFound(boolean simulatedVulnerabilityFound) {
+    this.simulatedVulnerabilityFound = simulatedVulnerabilityFound;
   }
 
   public boolean isColorEnabled() {


### PR DESCRIPTION
1. Fix typo in property.
2. Update README as we print CVEs in more then just red.