### PR TITLE
OSSIndex Audit - Sort vulnerabilities by cvss

### DIFF
--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -203,6 +203,7 @@ public class OssIndexAuditTask
     ComponentReport report = response.get(packageUrl);
     List<ComponentReportVulnerability> vulnerabilities =
         report != null ? report.getVulnerabilities() : Collections.emptyList();
+    vulnerabilities.sort(Comparator.comparing(ComponentReportVulnerability::getCvssScore).reversed());
 
     StringBuilder vulnerabilitiesText = new StringBuilder()
         .append(vulnerabilities.size())


### PR DESCRIPTION
Without PR (notice how red and orange vulnerabilities are mixed)
![image](https://user-images.githubusercontent.com/38332365/95357085-569f7a80-08bf-11eb-9489-ea4284779fb1.png)

With PR (vulnerabilities are sorted by cvss score)
![image](https://user-images.githubusercontent.com/38332365/95357111-60c17900-08bf-11eb-8a0f-d9dfda6ce34a.png)

cc @bhamail / @DarthHater / @guillermo-varela
