### PR TITLE
Improve support for Android projects with multiple modules and variants 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2.1
 orbs:
-  gradle: circleci/android:api-28-alpha
+  gradle: circleci/gradle@1.0.11
 executors:
   openjdk-8-executor:
     docker:
-      - image: 'circleci/openjdk:8'
+      - image: 'circleci/android:api-28-alpha'
 
 commands:
   configure-git:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  gradle: circleci/gradle@1.0.11
+  gradle: circleci/android:api-28-alpha
 executors:
   openjdk-8-executor:
     docker:

--- a/README.md
+++ b/README.md
@@ -143,21 +143,6 @@ As mentioned above the values can be set on command line using -D arguments or i
 Just apply the plugin on the root project and all sub-modules will be processed and the output will be a single report
 with all components found in each module. This includes Android projects.
 
-### Known issue with dependencies and build variants (mostly found in Android projects)
-Let's say an Android project has a module `core` with some code (library) and another module `app` as the actual Android
-app. When using build variants an error like this may show:
-
-> Could not resolve all dependencies for configuration ':app:releaseCompileClasspath'.
-More than one variant of project :core matches the consumer attributes
-      Configuration ':core:releaseApiElements' variant android-aidl: Unmatched attributes:
-      - Found artifactType 'android-aidl' but wasn't required.
-      - Found com.android.build.api.attributes.VariantAttr 'release' but wasn't required.
-
-At the moment, to get ride of that variant issue we recommend to change the way the library is declared in `app` by
-going to the `build.gradle` file from:
-    - `api project(':core')` or `implementation project(':core')` to
-    - `api project(path: ':core', configuration: 'default')` or `implementation project(path: ':core', configuration: 'default')`
-
 ## Contributing
 
 We care a lot about making the world a safer place, and that's why we created this `scan-gradle-plugin`. If you as well want to speed up the pace of software development by working on this project, jump on in! Before you start work, create a new issue, or comment on an existing issue, to let others know you are!

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ dependencies {
   testCompile "commons-io:commons-io:$commonsIoVersion"
   testCompile "org.powermock:powermock-module-junit4:$powermockVersion"
   testCompile "org.powermock:powermock-api-mockito2:$powermockVersion"
+  testCompile "com.github.ardenliu:arden-file:$ardenFileVersion"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,4 @@ junitVersion=4.13
 powermockVersion=2.0.4
 assertJVersion=3.14.0
 commonsIoVersion=2.6
+ardenFileVersion=0.0.4

--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -13,7 +13,7 @@ task integrationTest(type: Test) {
 }
 
 ['**/ScanIT_Gradle_Versions_3_3*.class',
- '**/ScanIT_Gradle_Versions_4_0*.class',
+ '**/ScanIT_Gradle_Versions_4_1*.class',
  '**/ScanIT_Gradle_Versions_4_4*.class',
  '**/ScanIT_Gradle_Versions_5_0*.class',
  '**/ScanIT_Gradle_Versions_5_5*.class',

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_3_3_to_4_0.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_3_3_to_4_0.java
@@ -5,15 +5,15 @@ import java.util.List;
 
 import org.junit.runners.Parameterized;
 
-public class ScanIT_Gradle_Versions_3_3_to_3_5
+public class ScanIT_Gradle_Versions_3_3_to_4_0
     extends ScanPluginIntegrationTestBase
 {
   @Parameterized.Parameters(name = "Version: {0}")
   public static List<String> data() {
-    return Arrays.asList("3.3", "3.4.1", "3.5");
+    return Arrays.asList("3.3", "3.5", "4.0");
   }
 
-  public ScanIT_Gradle_Versions_3_3_to_3_5(final String gradleVersion) {
+  public ScanIT_Gradle_Versions_3_3_to_4_0(final String gradleVersion) {
     super(gradleVersion);
     this.useLegacySyntax = true;
   }

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_4_1_to_4_3.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanIT_Gradle_Versions_4_1_to_4_3.java
@@ -5,15 +5,15 @@ import java.util.List;
 
 import org.junit.runners.Parameterized;
 
-public class ScanIT_Gradle_Versions_4_0_to_4_3
+public class ScanIT_Gradle_Versions_4_1_to_4_3
     extends ScanPluginIntegrationTestBase
 {
   @Parameterized.Parameters(name = "Version: {0}")
   public static List<String> data() {
-    return Arrays.asList("4.0", "4.1", "4.3.1");
+    return Arrays.asList("4.1", "4.2.1", "4.3.1");
   }
 
-  public ScanIT_Gradle_Versions_4_0_to_4_3(final String gradleVersion) {
+  public ScanIT_Gradle_Versions_4_1_to_4_3(final String gradleVersion) {
     super(gradleVersion);
   }
 }

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
 import com.github.ardenliu.common.file.ResourcesUtils;
@@ -134,7 +133,7 @@ public abstract class ScanPluginIntegrationTestBase
   }
 
   @Test
-  public void testScanTask_Android_NexusIQ() throws IOException, InterruptedException, URISyntaxException {
+  public void testScanTask_Android_NexusIQ() {
     String resource = useLegacySyntax ? "legacy-syntax" + File.separator + "android" : "android";
     ResourcesUtils.copyFromClassPath(resource, testProjectDir.getRoot().toPath());
 
@@ -200,8 +199,12 @@ public abstract class ScanPluginIntegrationTestBase
   public void testAuditTask_ExcludeTestDependencies_OssIndex() throws IOException {
     writeFile(buildFile, "exclude-test-dependency.gradle");
 
-    BuildResult result = GradleRunner.create().withGradleVersion(gradleVersion).withProjectDir(testProjectDir.getRoot())
-        .withPluginClasspath().withArguments("ossIndexAudit", "--info").build();
+    BuildResult result = GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .withProjectDir(testProjectDir.getRoot())
+        .withPluginClasspath()
+        .withArguments("ossIndexAudit", "--info")
+        .build();
 
     assertThat(result.getOutput()).contains("0 dependencies");
     assertThat(result.task(":ossIndexAudit").getOutcome()).isEqualTo(SUCCESS);
@@ -211,15 +214,19 @@ public abstract class ScanPluginIntegrationTestBase
   public void testAuditTask_IncludeTestDependencies_OssIndex() throws IOException {
     writeFile(buildFile, "include-test-dependency.gradle");
 
-    BuildResult result = GradleRunner.create().withGradleVersion(gradleVersion).withProjectDir(testProjectDir.getRoot())
-        .withPluginClasspath().withArguments("ossIndexAudit", "--info").build();
+    BuildResult result = GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .withProjectDir(testProjectDir.getRoot())
+        .withPluginClasspath()
+        .withArguments("ossIndexAudit", "--info")
+        .build();
 
     assertBuildOutputText_OssIndex(result, 0);
     assertThat(result.task(":ossIndexAudit").getOutcome()).isEqualTo(SUCCESS);
   }
 
   @Test
-  public void testAuditTask_Android_OssIndex() throws IOException, InterruptedException, URISyntaxException {
+  public void testAuditTask_Android_OssIndex() {
     String resource = useLegacySyntax ? "legacy-syntax" + File.separator + "android" : "android";
     ResourcesUtils.copyFromClassPath(resource, testProjectDir.getRoot().toPath());
 
@@ -227,7 +234,8 @@ public abstract class ScanPluginIntegrationTestBase
         .withGradleVersion(gradleVersion)
         .withProjectDir(new File(testProjectDir.getRoot(), resource))
         .withPluginClasspath()
-        .withArguments("ossIndexAudit", "--info").build();
+        .withArguments("ossIndexAudit", "--info")
+        .build();
 
     String resultOutput = result.getOutput();
     assertThat(resultOutput).contains(String.format(

--- a/src/integTest/resources/android/app/build.gradle
+++ b/src/integTest/resources/android/app/build.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'com.android.application'
+
+android {
+  compileSdkVersion rootProject.ext.compileSdkVersion
+
+  defaultConfig {
+    applicationId 'org.sonatype.gradle.plugins.scan.android'
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+    versionCode 1
+    versionName '1.0.0'
+    buildToolsVersion rootProject.ext.buildToolsVersion
+  }
+}
+
+dependencies {
+  implementation 'com.android.support:appcompat-v7:24.2.1'
+  implementation project(path: ':common-lib')
+}

--- a/src/integTest/resources/android/app/src/main/AndroidManifest.xml
+++ b/src/integTest/resources/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest package="com.inventage.sonatype.android.app"
+          xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+  <application android:name="org.sonatype.gradle.plugins.scan.android" />
+</manifest>

--- a/src/integTest/resources/android/build.gradle
+++ b/src/integTest/resources/android/build.gradle
@@ -23,9 +23,9 @@ allprojects {
 }
 
 ext {
-  compileSdkVersion=29
+  compileSdkVersion=28
   minSdkVersion=10
-  targetSdkVersion=29
+  targetSdkVersion=28
   buildToolsVersion="26.0.2"
 }
 

--- a/src/integTest/resources/android/build.gradle
+++ b/src/integTest/resources/android/build.gradle
@@ -1,0 +1,42 @@
+buildscript {
+  repositories {
+    google()
+    mavenCentral()
+    jcenter()
+  }
+
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.0.0'
+  }
+}
+
+plugins {
+  id 'org.sonatype.gradle.plugins.scan'
+}
+
+allprojects {
+  repositories {
+    google()
+    mavenCentral()
+    jcenter()
+  }
+}
+
+ext {
+  compileSdkVersion=29
+  minSdkVersion=10
+  targetSdkVersion=29
+  buildToolsVersion="26.0.2"
+}
+
+nexusIQScan {
+  serverUrl = 'http://localhost:8081'
+  username = 'admin'
+  password = 'admin123'
+  applicationId = 'testing-gradle-plugin'
+  simulationEnabled = true
+}
+
+ossIndexAudit {
+  simulationEnabled = true
+}

--- a/src/integTest/resources/android/build.gradle
+++ b/src/integTest/resources/android/build.gradle
@@ -5,8 +5,17 @@ buildscript {
     jcenter()
   }
 
+  // Mapping between Gradle and Android plugin versions: https://developer.android.com/studio/releases/gradle-plugin
+  def androidGradlePluginVersion = '3.0.0'
+  if (gradle.gradleVersion.compareTo('6.1.1') >= 0) {
+    androidGradlePluginVersion = '4.0.0'
+  } else if (gradle.gradleVersion.compareTo('5.6.4') >= 0) {
+    androidGradlePluginVersion = '3.6.4'
+  } else if (gradle.gradleVersion.compareTo('5.0') >= 0) {
+    androidGradlePluginVersion = '3.3.3'
+  }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.0'
+    classpath "com.android.tools.build:gradle:$androidGradlePluginVersion"
   }
 }
 
@@ -26,7 +35,7 @@ ext {
   compileSdkVersion=28
   minSdkVersion=10
   targetSdkVersion=28
-  buildToolsVersion="26.0.2"
+  buildToolsVersion='26.0.2'
 }
 
 nexusIQScan {

--- a/src/integTest/resources/android/common-lib/build.gradle
+++ b/src/integTest/resources/android/common-lib/build.gradle
@@ -1,0 +1,17 @@
+apply plugin: 'com.android.library'
+
+android {
+  compileSdkVersion rootProject.ext.compileSdkVersion
+
+  defaultConfig {
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+    versionCode 1
+    versionName '1.0'
+    buildToolsVersion rootProject.ext.buildToolsVersion
+  }
+}
+
+dependencies {
+  implementation 'commons-collections:commons-collections:3.1'
+}

--- a/src/integTest/resources/android/common-lib/src/main/AndroidManifest.xml
+++ b/src/integTest/resources/android/common-lib/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest package="com.inventage.sonatype.android.app"
+          xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+  <application android:name="org.sonatype.gradle.plugins.scan.android" />
+</manifest>

--- a/src/integTest/resources/android/settings.gradle
+++ b/src/integTest/resources/android/settings.gradle
@@ -1,0 +1,1 @@
+include ':common-lib', ':app'

--- a/src/integTest/resources/legacy-syntax/android/app/build.gradle
+++ b/src/integTest/resources/legacy-syntax/android/app/build.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'com.android.application'
+
+android {
+  compileSdkVersion rootProject.ext.compileSdkVersion
+
+  defaultConfig {
+    applicationId 'org.sonatype.gradle.plugins.scan.android'
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+    versionCode 1
+    versionName '1.0.0'
+    buildToolsVersion rootProject.ext.buildToolsVersion
+  }
+}
+
+dependencies {
+  compile 'com.android.support:appcompat-v7:24.2.1'
+  compile project(path: ':common-lib')
+}

--- a/src/integTest/resources/legacy-syntax/android/app/src/main/AndroidManifest.xml
+++ b/src/integTest/resources/legacy-syntax/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest package="com.inventage.sonatype.android.app"
+          xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+  <application android:name="org.sonatype.gradle.plugins.scan.android" />
+</manifest>

--- a/src/integTest/resources/legacy-syntax/android/build.gradle
+++ b/src/integTest/resources/legacy-syntax/android/build.gradle
@@ -21,9 +21,9 @@ allprojects {
 }
 
 ext {
-  compileSdkVersion=29
+  compileSdkVersion=28
   minSdkVersion=10
-  targetSdkVersion=29
+  targetSdkVersion=28
   buildToolsVersion="26.0.2"
 }
 

--- a/src/integTest/resources/legacy-syntax/android/build.gradle
+++ b/src/integTest/resources/legacy-syntax/android/build.gradle
@@ -24,7 +24,7 @@ ext {
   compileSdkVersion=28
   minSdkVersion=10
   targetSdkVersion=28
-  buildToolsVersion="26.0.2"
+  buildToolsVersion='26.0.2'
 }
 
 nexusIQScan {

--- a/src/integTest/resources/legacy-syntax/android/build.gradle
+++ b/src/integTest/resources/legacy-syntax/android/build.gradle
@@ -1,0 +1,40 @@
+buildscript {
+  repositories {
+    maven { url 'https://maven.google.com' }
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath 'com.android.tools.build:gradle:2.3.0'
+  }
+}
+
+plugins {
+  id 'org.sonatype.gradle.plugins.scan'
+}
+
+allprojects {
+  repositories {
+    maven { url 'https://maven.google.com' }
+    mavenCentral()
+  }
+}
+
+ext {
+  compileSdkVersion=29
+  minSdkVersion=10
+  targetSdkVersion=29
+  buildToolsVersion="26.0.2"
+}
+
+nexusIQScan {
+  serverUrl = 'http://localhost:8081'
+  username = 'admin'
+  password = 'admin123'
+  applicationId = 'testing-gradle-plugin'
+  simulationEnabled = true
+}
+
+ossIndexAudit {
+  simulationEnabled = true
+}

--- a/src/integTest/resources/legacy-syntax/android/common-lib/build.gradle
+++ b/src/integTest/resources/legacy-syntax/android/common-lib/build.gradle
@@ -1,0 +1,17 @@
+apply plugin: 'com.android.library'
+
+android {
+  compileSdkVersion rootProject.ext.compileSdkVersion
+
+  defaultConfig {
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+    versionCode 1
+    versionName '1.0'
+    buildToolsVersion rootProject.ext.buildToolsVersion
+  }
+}
+
+dependencies {
+  compile 'commons-collections:commons-collections:3.1'
+}

--- a/src/integTest/resources/legacy-syntax/android/common-lib/src/main/AndroidManifest.xml
+++ b/src/integTest/resources/legacy-syntax/android/common-lib/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest package="com.inventage.sonatype.android.app"
+          xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+  <application android:name="org.sonatype.gradle.plugins.scan.android" />
+</manifest>

--- a/src/integTest/resources/legacy-syntax/android/settings.gradle
+++ b/src/integTest/resources/legacy-syntax/android/settings.gradle
@@ -1,0 +1,1 @@
+include ':common-lib', ':app'

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
@@ -75,6 +75,8 @@ public class NexusIqScanTask
               Collections.singletonList(new Action(extension.getSimulatedPolicyActionId()))));
         }
 
+        dependenciesFinder.findModules(getProject(), extension.isAllConfigurations());
+
         applicationPolicyEvaluation =
             new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, alerts, "simulated/report");
       }


### PR DESCRIPTION
Improves support for Android projects with multiple modules and variants by adding a fallback for the case a Gradle configuration cannot resolve its dependencies due to multiple candidates being found.

Also specific Android tests are added to ensure the plugin works for Android.

It relates to the following issue #s:
* Fixes #41 