### PR TITLE
Proxy configuration for OSS Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ ossIndexAudit {
     cacheExpiration = 'PT12H' // 12 hours if omitted. It must follow the Joda Time specification at https://www.javadoc.io/doc/joda-time/joda-time/2.10.4/org/joda/time/Duration.html#parse-java.lang.String-
     colorEnabled = false // if true prints vulnerability description in color. By default is true.
     dependencyGraph = true // if true prints dependency graph showing direct/transitive dependencies. By default is false.  
+    proxyConfiguration { // extra configuration when running behind a proxy without direct internet access
+        protocol = 'http' // can be 'http' (default) or 'https'
+        host = 'proxy-host' // hostname for the proxy
+        port = 8080 // port for the proxy
+        authConfiguration.username = 'username' // username for the proxy (if credentials are required)
+        authConfiguration.password = 'password' // password for the proxy (if credentials are required)
+    }
 }
 ```
 - Open Terminal on the project's root and run `./gradlew ossIndexAudit`

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexClientConfigurationBuilder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexClientConfigurationBuilder.java
@@ -65,6 +65,8 @@ public class OssIndexClientConfigurationBuilder
 
         clientConfiguration.setCacheConfiguration(cacheConfig);
       }
+
+      clientConfiguration.setProxyConfiguration(extension.getProxyConfiguration());
     }
 
     return clientConfiguration;

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -15,6 +15,11 @@
  */
 package org.sonatype.gradle.plugins.scan.ossindex;
 
+import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
+import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
+
+import groovy.lang.Closure;
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;
 
 public class OssIndexPluginExtension
@@ -43,6 +48,8 @@ public class OssIndexPluginExtension
   private boolean colorEnabled;
 
   private boolean dependencyGraph;
+
+  private ProxyConfiguration proxyConfiguration;
 
   public OssIndexPluginExtension(Project project) {
     username = "";
@@ -134,5 +141,23 @@ public class OssIndexPluginExtension
 
   public void setDependencyGraph(boolean dependencyGraph) {
     this.dependencyGraph = dependencyGraph;
+  }
+
+  public ProxyConfiguration getProxyConfiguration() {
+    return proxyConfiguration;
+  }
+
+  public void setProxyConfiguration(Closure<ProxyConfiguration> closure) {
+    proxyConfiguration = new ProxyConfiguration();
+    AuthConfiguration authConfiguration = new AuthConfiguration();
+    proxyConfiguration.setAuthConfiguration(authConfiguration);
+
+    closure.setResolveStrategy(Closure.DELEGATE_FIRST);
+    closure.setDelegate(proxyConfiguration);
+    closure.call();
+
+    if (StringUtils.isAllBlank(authConfiguration.getUsername(), authConfiguration.getPassword())) {
+      proxyConfiguration.setAuthConfiguration(null);
+    }
   }
 }


### PR DESCRIPTION
Allows to setup proxy details for OSS Index when running in a network without direct internet access.

It relates to the following issue #s:
* Fixes #40 