### PR TITLE
Hide non vulnerable dependencies for OSS Index output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ ossIndexAudit {
         authConfiguration.username = 'username' // username for the proxy (if credentials are required)
         authConfiguration.password = 'password' // password for the proxy (if credentials are required)
     }
+    showAll = true // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.   
 }
 ```
 - Open Terminal on the project's root and run `./gradlew ossIndexAudit`

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ossIndexAudit {
     cacheDirectory = 'some/path' // by default it uses the user data directory (according to OS)
     cacheExpiration = 'PT12H' // 12 hours if omitted. It must follow the Joda Time specification at https://www.javadoc.io/doc/joda-time/joda-time/2.10.4/org/joda/time/Duration.html#parse-java.lang.String-
     colorEnabled = false // if true prints vulnerability description in color. By default is true.
-    dependencyGraph = true // if true prints dependency graph showing direct/transitive dependencies. By default is false.  
+    dependencyGraph = true // if true prints dependency graph showing direct/transitive dependencies. By default is false.
     proxyConfiguration { // extra configuration when running behind a proxy without direct internet access
         protocol = 'http' // can be 'http' (default) or 'https'
         host = 'proxy-host' // hostname for the proxy
@@ -76,7 +76,7 @@ ossIndexAudit {
         authConfiguration.username = 'username' // username for the proxy (if credentials are required)
         authConfiguration.password = 'password' // password for the proxy (if credentials are required)
     }
-    showAll = true // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.   
+    showAll = true // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
 }
 ```
 - Open Terminal on the project's root and run `./gradlew ossIndexAudit`

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
@@ -149,7 +149,24 @@ public abstract class ScanPluginIntegrationTestBase
   }
 
   @Test
-  public void testAuditTask_NoVulnerabilities_OssIndex_Default() throws IOException {
+  public void testAuditTask_NoVulnerabilities_OssIndex_Default_Empty() throws IOException {
+    writeFile(buildFile, "control_default_not_all.gradle");
+
+    final BuildResult result = GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .withProjectDir(testProjectDir.getRoot())
+        .withPluginClasspath()
+        .withArguments("ossIndexAudit", "--info")
+        .build();
+
+    String resultOutput = result.getOutput();
+    assertThat(resultOutput).contains("No vulnerabilities found!");
+    assertThat(resultOutput).doesNotContain("commons-collections");
+    assertThat(result.task(":ossIndexAudit").getOutcome()).isEqualTo(SUCCESS);
+  }
+
+  @Test
+  public void testAuditTask_NoVulnerabilities_OssIndex_Default_ShowAll() throws IOException {
     writeFile(buildFile, "control_default.gradle");
 
     final BuildResult result = GradleRunner.create()
@@ -165,7 +182,24 @@ public abstract class ScanPluginIntegrationTestBase
   }
 
   @Test
-  public void testAuditTask_NoVulnerabilities_OssIndex_DependencyGraph() throws IOException {
+  public void testAuditTask_NoVulnerabilities_OssIndex_DependencyGraph_Empty() throws IOException {
+    writeFile(buildFile, "control_dependency_graph_not_all.gradle");
+
+    final BuildResult result = GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .withProjectDir(testProjectDir.getRoot())
+        .withPluginClasspath()
+        .withArguments("ossIndexAudit", "--info")
+        .build();
+
+    String resultOutput = result.getOutput();
+    assertThat(resultOutput).contains("No vulnerabilities found!");
+    assertThat(resultOutput).doesNotContain("commons-collections");
+    assertThat(result.task(":ossIndexAudit").getOutcome()).isEqualTo(SUCCESS);
+  }
+
+  @Test
+  public void testAuditTask_NoVulnerabilities_OssIndex_DependencyGraph_ShowAll() throws IOException {
     writeFile(buildFile, "control_dependency_graph.gradle");
 
     final BuildResult result = GradleRunner.create()

--- a/src/integTest/resources/android/build.gradle
+++ b/src/integTest/resources/android/build.gradle
@@ -49,4 +49,5 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   dependencyGraph = true
+  showAll = true
 }

--- a/src/integTest/resources/control_default.gradle
+++ b/src/integTest/resources/control_default.gradle
@@ -21,4 +21,5 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   colorEnabled = false
+  showAll = true
 }

--- a/src/integTest/resources/control_default_not_all.gradle
+++ b/src/integTest/resources/control_default_not_all.gradle
@@ -20,6 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
-  showAll = true
+  colorEnabled = false
 }

--- a/src/integTest/resources/control_dependency_graph_not_all.gradle
+++ b/src/integTest/resources/control_dependency_graph_not_all.gradle
@@ -21,5 +21,4 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   dependencyGraph = true
-  showAll = true
 }

--- a/src/integTest/resources/include-test-default.gradle
+++ b/src/integTest/resources/include-test-default.gradle
@@ -14,4 +14,5 @@ dependencies {
 ossIndexAudit {
   allConfigurations = true
   simulationEnabled = true
+  showAll = true
 }

--- a/src/integTest/resources/include-test-dependency-graph.gradle
+++ b/src/integTest/resources/include-test-dependency-graph.gradle
@@ -15,4 +15,5 @@ ossIndexAudit {
   allConfigurations = true
   simulationEnabled = true
   dependencyGraph = true
+  showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/android/build.gradle
+++ b/src/integTest/resources/legacy-syntax/android/build.gradle
@@ -38,4 +38,5 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   dependencyGraph = true
+  showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/control_default.gradle
+++ b/src/integTest/resources/legacy-syntax/control_default.gradle
@@ -21,4 +21,5 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   colorEnabled = false
+  showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/control_default_not_all.gradle
+++ b/src/integTest/resources/legacy-syntax/control_default_not_all.gradle
@@ -7,7 +7,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'commons-collections:commons-collections:3.1'
+  compile 'commons-collections:commons-collections:3.1'
 }
 
 nexusIQScan {
@@ -20,6 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
-  showAll = true
+  colorEnabled = false
 }

--- a/src/integTest/resources/legacy-syntax/control_dependency_graph.gradle
+++ b/src/integTest/resources/legacy-syntax/control_dependency_graph.gradle
@@ -21,4 +21,5 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   dependencyGraph = true
+  showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/control_dependency_graph_not_all.gradle
+++ b/src/integTest/resources/legacy-syntax/control_dependency_graph_not_all.gradle
@@ -7,7 +7,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'commons-collections:commons-collections:3.1'
+  compile 'commons-collections:commons-collections:3.1'
 }
 
 nexusIQScan {
@@ -21,5 +21,4 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   dependencyGraph = true
-  showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/include-test-default.gradle
+++ b/src/integTest/resources/legacy-syntax/include-test-default.gradle
@@ -14,4 +14,5 @@ dependencies {
 ossIndexAudit {
   allConfigurations = true
   simulationEnabled = true
+  showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/include-test-dependency-graph.gradle
+++ b/src/integTest/resources/legacy-syntax/include-test-dependency-graph.gradle
@@ -15,4 +15,5 @@ ossIndexAudit {
   allConfigurations = true
   simulationEnabled = true
   dependencyGraph = true
+  showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/transitive-dependencies.gradle
+++ b/src/integTest/resources/legacy-syntax/transitive-dependencies.gradle
@@ -12,4 +12,5 @@ dependencies {
 ossIndexAudit {
   colorEnabled = false
   dependencyGraph = true
+  showAll = true
 }

--- a/src/integTest/resources/transitive-dependencies.gradle
+++ b/src/integTest/resources/transitive-dependencies.gradle
@@ -12,4 +12,5 @@ dependencies {
 ossIndexAudit {
   colorEnabled = false
   dependencyGraph = true
+  showAll = true
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/DefaultResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/DefaultResponseHandler.java
@@ -56,10 +56,13 @@ public class DefaultResponseHandler
       ComponentReport componentReport = response.get(packageUrl);
 
       List<ComponentReportVulnerability> vulnerabilities = getSortedVulnerabilities(componentReport);
-      log.info(getProcessingPackageUrlString(packageUrl, vulnerabilities, index++, dependenciesMap.size()));
-      for (ComponentReportVulnerability vulnerability : vulnerabilities) {
-        log.info((getVulnerabilityDetailsString(vulnerability)));
+      if (!vulnerabilities.isEmpty() || extension.isShowAll()) {
+        log.info(getProcessingPackageUrlString(packageUrl, vulnerabilities, index, dependenciesMap.size()));
+        for (ComponentReportVulnerability vulnerability : vulnerabilities) {
+          log.info((getVulnerabilityDetailsString(vulnerability)));
+        }
       }
+      index++;
 
       boolean vulnerable = !vulnerabilities.isEmpty();
       if (vulnerable) {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/DefaultResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/DefaultResponseHandler.java
@@ -45,11 +45,22 @@ public class DefaultResponseHandler
       final Map<ResolvedDependency, PackageUrl> dependenciesMap,
       final Map<PackageUrl, ComponentReport> response)
   {
-    log.info(BannerUtils.createBanner());
-    log.info("Checking vulnerabilities in {} dependencies", dependenciesMap.size());
-
     boolean hasVulnerabilities = false;
     int index = 1;
+    int dependenciesCount = dependenciesMap.size();
+
+    if (!extension.isShowAll()) {
+      dependenciesCount = (int) dependenciesMap.values().parallelStream()
+          .filter(packageUrl -> !response.get(packageUrl).getVulnerabilities().isEmpty())
+          .count();
+
+      if (dependenciesCount == 0) {
+        log.info("No vulnerabilities found!");
+      }
+      else {
+        log.info("Found vulnerabilities in {} dependencies", dependenciesCount);
+      }
+    }
 
     for (Entry<ResolvedDependency, PackageUrl> entry : dependenciesMap.entrySet()) {
       PackageUrl packageUrl = entry.getValue();
@@ -57,12 +68,11 @@ public class DefaultResponseHandler
 
       List<ComponentReportVulnerability> vulnerabilities = getSortedVulnerabilities(componentReport);
       if (!vulnerabilities.isEmpty() || extension.isShowAll()) {
-        log.info(getProcessingPackageUrlString(packageUrl, vulnerabilities, index, dependenciesMap.size()));
+        log.info(getProcessingPackageUrlString(packageUrl, vulnerabilities, index++, dependenciesCount));
         for (ComponentReportVulnerability vulnerability : vulnerabilities) {
-          log.info((getVulnerabilityDetailsString(vulnerability)));
+          log.info(getVulnerabilityDetailsString(vulnerability));
         }
       }
-      index++;
 
       boolean vulnerable = !vulnerabilities.isEmpty();
       if (vulnerable) {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/DependencyGraphResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/DependencyGraphResponseHandler.java
@@ -59,6 +59,9 @@ public class DependencyGraphResponseHandler
         log.info("No vulnerabilities found!");
         return false;
       }
+      else {
+        log.info("Found vulnerabilities in {} dependencies", dependenciesMap.size());
+      }
     }
 
     Set<PackageUrl> processedPackageUrls = new HashSet<>();

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/DependencyGraphResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/DependencyGraphResponseHandler.java
@@ -20,6 +20,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -50,11 +51,15 @@ public class DependencyGraphResponseHandler
       Set<ResolvedDependency> dependencies,
       Map<ResolvedDependency, PackageUrl> dependenciesMap,
       Map<PackageUrl, ComponentReport> response) {
-
-    log.info(BannerUtils.createBanner());
-    log.info("Checking vulnerabilities in {} dependencies", dependenciesMap.size());
-
     boolean hasVulnerabilities = false;
+
+    if (!extension.isShowAll()) {
+      dependenciesMap = getDependenciesMapWithVulnerabilities(dependenciesMap, response);
+      if (dependenciesMap.isEmpty()) {
+        log.info("No vulnerabilities found!");
+        return false;
+      }
+    }
 
     Set<PackageUrl> processedPackageUrls = new HashSet<>();
     for (ResolvedDependency dependency : dependencies) {
@@ -80,6 +85,11 @@ public class DependencyGraphResponseHandler
       String prefix)
   {
     PackageUrl packageUrl = dependenciesMap.get(dependency);
+
+    if (packageUrl == null) {
+      return false;
+    }
+
     ComponentReport report = response.get(packageUrl);
     List<ComponentReportVulnerability> vulnerabilities =
         report != null ? report.getVulnerabilities() : Collections.emptyList();
@@ -131,8 +141,7 @@ public class DependencyGraphResponseHandler
     String indent = System.lineSeparator() +
         StringUtils.replaceOnce(prefix, DEPENDENCY_PREFIX, StringUtils.repeat(" ", DEPENDENCY_PREFIX.length()));
 
-    StringBuilder builder = new StringBuilder()
-        .append(vulnerability.getTitle());
+    StringBuilder builder = new StringBuilder(vulnerability.getTitle());
 
     Float cvssScore = vulnerability.getCvssScore();
     if (cvssScore != null) {
@@ -151,5 +160,26 @@ public class DependencyGraphResponseHandler
       vulnerabilityText = VulnerabilityUtils.addColorBasedOnCvssScore(cvssScore, vulnerabilityText);
     }
     return indent + vulnerabilityText;
+  }
+
+  private Map<ResolvedDependency, PackageUrl> getDependenciesMapWithVulnerabilities(
+      Map<ResolvedDependency, PackageUrl> dependenciesMap,
+      Map<PackageUrl, ComponentReport> response)
+  {
+    return dependenciesMap.entrySet().parallelStream()
+        .filter(entry -> hasVulnerabilities(entry.getKey(), dependenciesMap, response))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+  }
+
+  private boolean hasVulnerabilities(
+      ResolvedDependency dependency,
+      Map<ResolvedDependency, PackageUrl> dependenciesMap,
+      Map<PackageUrl, ComponentReport> response)
+  {
+    PackageUrl packageUrl = dependenciesMap.get(dependency);
+    return !response.get(packageUrl).getVulnerabilities().isEmpty() || dependency.getChildren().parallelStream()
+        .map(child -> hasVulnerabilities(child, dependenciesMap, response))
+        .collect(Collectors.toList())
+        .contains(true);
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -46,10 +46,14 @@ import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OssIndexAuditTask
     extends DefaultTask
 {
+  private static Logger log = LoggerFactory.getLogger(OssIndexResponseHandler.class);
+
   private final OssIndexPluginExtension extension;
 
   private final DependenciesFinder dependenciesFinder;
@@ -75,6 +79,9 @@ public class OssIndexAuditTask
       List<PackageUrl> packageUrls = new ArrayList<>(dependenciesMap.values());
 
       Map<PackageUrl, ComponentReport> response;
+
+      log.info(BannerUtils.createBanner());
+      log.info("Checking vulnerabilities in {} dependencies", dependenciesMap.size());
 
       if (extension.isSimulationEnabled()) {
         response = buildSimulatedResponse(packageUrls);
@@ -194,5 +201,10 @@ public class OssIndexAuditTask
   @Input
   public boolean isDependencyGraph() {
     return extension.isDependencyGraph();
+  }
+
+  @Input
+  public boolean isShowAll() {
+    return extension.isShowAll();
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -51,6 +51,8 @@ public class OssIndexPluginExtension
 
   private ProxyConfiguration proxyConfiguration;
 
+  private boolean showAll;
+
   public OssIndexPluginExtension(Project project) {
     username = "";
     password = "";
@@ -61,6 +63,7 @@ public class OssIndexPluginExtension
     simulatedVulnerabilityFound = false;
     colorEnabled = true;
     dependencyGraph = false;
+    showAll = false;
   }
 
   public String getUsername() {
@@ -159,5 +162,13 @@ public class OssIndexPluginExtension
     if (StringUtils.isAllBlank(authConfiguration.getUsername(), authConfiguration.getPassword())) {
       proxyConfiguration.setAuthConfiguration(null);
     }
+  }
+
+  public boolean isShowAll() {
+    return showAll;
+  }
+
+  public void setShowAll(boolean showAll) {
+    this.showAll = showAll;
   }
 }


### PR DESCRIPTION
With this PR only dependencies with vulnerabilities found in OSS Index will be printed by default (both on the table and in the graph outputs).

A flag `showAll` can be use to see the whole dependencies list.

It relates to the following issue #s:
* Fixes #28 