### PR TITLE
Add support for excluding vulnerabilities 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ ossIndexAudit {
         authConfiguration.password = 'password' // password for the proxy (if credentials are required)
     }
     showAll = true // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
+    
+    // ossIndexAudit can be configued to exclude vulnerabilities from matching
+    excludeVulnerabilityIds = ['39d74cc8-457a-4e57-89ef-a258420138c5'] list containing ids of vulnerabilities to be ignored
+    excludeCoordinates = ['commons-fileupload:commons-fileupload:1.3'] list containing coordinate of components which if vulnerable should be ignored
 }
 ```
 - Open Terminal on the project's root and run `./gradlew ossIndexAudit`

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
@@ -245,6 +245,34 @@ public abstract class ScanPluginIntegrationTestBase
   }
 
   @Test
+  public void testAuditTask_ExcludeVulnerabilities_ByVulnerabilityId_OssIndex() throws IOException {
+    writeFile(buildFile, "exclude_vulnerabilities_by_vulnerability_id.gradle");
+
+    final BuildResult result = GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .withProjectDir(testProjectDir.getRoot())
+        .withPluginClasspath()
+        .withArguments("ossIndexAudit", "--info")
+        .build();
+
+    assertBuildOutputText_ExcludeVulnerabilities_OssIndex(result);
+  }
+
+  @Test
+  public void testAuditTask_ExcludeVulnerabilities_ByCoordinate_OssIndex() throws IOException {
+    writeFile(buildFile, "exclude_vulnerabilities_by_coordinate.gradle");
+
+    final BuildResult result = GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .withProjectDir(testProjectDir.getRoot())
+        .withPluginClasspath()
+        .withArguments("ossIndexAudit", "--info")
+        .build();
+
+    assertBuildOutputText_ExcludeVulnerabilities_OssIndex(result);
+  }
+
+  @Test
   public void testAuditTask_TransitiveDepdendencies_OssIndex() throws IOException {
     writeFile(buildFile, "transitive-dependencies.gradle");
 
@@ -372,5 +400,12 @@ public abstract class ScanPluginIntegrationTestBase
   private void assertBuildOutputText_OssIndex_Default(BuildResult result, String expectedText) {
     String resultOutput = result.getOutput();
     assertThat(resultOutput).contains(expectedText);
+  }
+
+  private void assertBuildOutputText_ExcludeVulnerabilities_OssIndex(BuildResult result) {
+    String resultOutput = result.getOutput();
+    assertThat(resultOutput).contains("No vulnerabilities found!");
+    assertThat(resultOutput).doesNotContain("commons-collections");
+    assertThat(result.task(":ossIndexAudit").getOutcome()).isEqualTo(SUCCESS);
   }
 }

--- a/src/integTest/resources/exclude_vulnerabilities_by_coordinate.gradle
+++ b/src/integTest/resources/exclude_vulnerabilities_by_coordinate.gradle
@@ -1,0 +1,19 @@
+plugins {
+  id 'java'
+  id 'org.sonatype.gradle.plugins.scan'
+}
+
+repositories {
+  mavenCentral()
+}
+dependencies {
+  implementation 'commons-collections:commons-collections:3.1'
+}
+
+
+
+ossIndexAudit {
+  simulationEnabled = true
+  simulatedVulnerabilityFound = true
+  excludeCoordinates = ['commons-collections:commons-collections:3.1']
+}

--- a/src/integTest/resources/exclude_vulnerabilities_by_vulnerability_id.gradle
+++ b/src/integTest/resources/exclude_vulnerabilities_by_vulnerability_id.gradle
@@ -1,0 +1,19 @@
+plugins {
+  id 'java'
+  id 'org.sonatype.gradle.plugins.scan'
+}
+
+repositories {
+  mavenCentral()
+}
+dependencies {
+  implementation 'commons-collections:commons-collections:3.1'
+}
+
+
+
+ossIndexAudit {
+  simulationEnabled = true
+  simulatedVulnerabilityFound = true
+  excludeVulnerabilityIds = ['123-456-789']
+}

--- a/src/integTest/resources/legacy-syntax/exclude_vulnerabilities_by_coordinate.gradle
+++ b/src/integTest/resources/legacy-syntax/exclude_vulnerabilities_by_coordinate.gradle
@@ -15,6 +15,5 @@ dependencies {
 ossIndexAudit {
   simulationEnabled = true
   simulatedVulnerabilityFound = true
-  dependencyGraph = true
   excludeCoordinates = ['commons-collections:commons-collections:3.1']
 }

--- a/src/integTest/resources/legacy-syntax/exclude_vulnerabilities_by_coordinate.gradle
+++ b/src/integTest/resources/legacy-syntax/exclude_vulnerabilities_by_coordinate.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'java'
+  id 'org.sonatype.gradle.plugins.scan'
+}
+
+repositories {
+  mavenCentral()
+}
+dependencies {
+  testCompile 'commons-collections:commons-collections:3.1'
+}
+
+
+
+ossIndexAudit {
+  simulationEnabled = true
+  simulatedVulnerabilityFound = true
+  dependencyGraph = true
+  excludeCoordinates = ['commons-collections:commons-collections:3.1']
+}

--- a/src/integTest/resources/legacy-syntax/exclude_vulnerabilities_by_vulnerability_id.gradle
+++ b/src/integTest/resources/legacy-syntax/exclude_vulnerabilities_by_vulnerability_id.gradle
@@ -15,6 +15,5 @@ dependencies {
 ossIndexAudit {
   simulationEnabled = true
   simulatedVulnerabilityFound = true
-  dependencyGraph = true
   excludeVulnerabilityIds = ['123-456-789']
 }

--- a/src/integTest/resources/legacy-syntax/exclude_vulnerabilities_by_vulnerability_id.gradle
+++ b/src/integTest/resources/legacy-syntax/exclude_vulnerabilities_by_vulnerability_id.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'java'
+  id 'org.sonatype.gradle.plugins.scan'
+}
+
+repositories {
+  mavenCentral()
+}
+dependencies {
+  testCompile 'commons-collections:commons-collections:3.1'
+}
+
+
+
+ossIndexAudit {
+  simulationEnabled = true
+  simulatedVulnerabilityFound = true
+  dependencyGraph = true
+  excludeVulnerabilityIds = ['123-456-789']
+}

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -19,7 +19,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -41,6 +40,7 @@ import org.sonatype.ossindex.service.client.transport.Transport.TransportExcepti
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Lists;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -138,10 +138,11 @@ public class OssIndexAuditTask
 
       if (extension.isSimulatedVulnerabilityFound()) {
         ComponentReportVulnerability vulnerability = new ComponentReportVulnerability();
+        vulnerability.setId("123-456-789");
         vulnerability.setTitle("Simulated");
         vulnerability.setCvssScore(4f);
         vulnerability.setReference(new URI("http://test/123"));
-        report.setVulnerabilities(Arrays.asList(vulnerability));
+        report.setVulnerabilities(Lists.newArrayList(vulnerability));
       }
 
       map.put(packageUrl, report);

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -15,6 +15,9 @@
  */
 package org.sonatype.gradle.plugins.scan.ossindex;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
 
@@ -53,6 +56,10 @@ public class OssIndexPluginExtension
 
   private boolean showAll;
 
+  private Set<String> excludeVulnerabilityIds;
+
+  private Set<String> excludeCoordinates;
+
   public OssIndexPluginExtension(Project project) {
     username = "";
     password = "";
@@ -64,6 +71,8 @@ public class OssIndexPluginExtension
     colorEnabled = true;
     dependencyGraph = false;
     showAll = false;
+    excludeVulnerabilityIds = new HashSet<>();
+    excludeCoordinates = new HashSet<>();
   }
 
   public String getUsername() {
@@ -170,5 +179,21 @@ public class OssIndexPluginExtension
 
   public void setShowAll(boolean showAll) {
     this.showAll = showAll;
+  }
+
+  public Set<String> getExcludeVulnerabilityIds() {
+    return excludeVulnerabilityIds;
+  }
+
+  public void setExcludeVulnerabilityIds(Set<String> excludeVulnerabilityIds) {
+    this.excludeVulnerabilityIds = excludeVulnerabilityIds;
+  }
+
+  public Set<String> getExcludeCoordinates() {
+    return excludeCoordinates;
+  }
+
+  public void setExcludeCoordinates(Set<String> excludeCoordinates) {
+    this.excludeCoordinates = excludeCoordinates;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/VulnerabilityExclusionFilter.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/VulnerabilityExclusionFilter.java
@@ -42,11 +42,12 @@ public class VulnerabilityExclusionFilter
         PackageUrl packageUrl = entry.getKey();
         List<ComponentReportVulnerability> vulnerabilities = entry.getValue().getVulnerabilities();
 
-        if (excludeByCoordinate(packageUrl) && !vulnerabilities.isEmpty()) {
-          report.remove(packageUrl);
+        if (excludeByCoordinate(packageUrl)) {
+          vulnerabilities.clear();
         }
-
-        vulnerabilities.removeIf(this::excludeByVulnerabilityId);
+        else {
+          vulnerabilities.removeIf(this::excludeByVulnerabilityId);
+        }
       }
     }
   }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/VulnerabilityExclusionFilter.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/VulnerabilityExclusionFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.ossindex;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+
+import org.sonatype.goodies.packageurl.PackageUrl;
+import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
+import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerability;
+
+public class VulnerabilityExclusionFilter
+{
+  private final Set<String> vulnerabilityIds;
+
+  private final Set<PackageUrl> coordinates;
+
+  public VulnerabilityExclusionFilter(Set<String> vulnerabilityIds, Set<PackageUrl> coordinates) {
+    this.vulnerabilityIds = vulnerabilityIds;
+    this.coordinates = coordinates;
+  }
+
+  public void apply(Map<PackageUrl, ComponentReport> report) {
+    if (!vulnerabilityIds.isEmpty() || !coordinates.isEmpty()) {
+      for (Entry<PackageUrl, ComponentReport> entry : report.entrySet()) {
+        PackageUrl packageUrl = entry.getKey();
+        List<ComponentReportVulnerability> vulnerabilities = entry.getValue().getVulnerabilities();
+
+        if (excludeByCoordinate(packageUrl) && !vulnerabilities.isEmpty()) {
+          report.remove(packageUrl);
+        }
+
+        vulnerabilities.removeIf(this::excludeByVulnerabilityId);
+      }
+    }
+  }
+
+  private boolean excludeByCoordinate(PackageUrl coordinate) {
+    for (PackageUrl packageUrl : coordinates) {
+      if (Objects.equals(coordinate, packageUrl)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean excludeByVulnerabilityId(ComponentReportVulnerability vulnerability) {
+    for (String vulnerabilityId : vulnerabilityIds) {
+      if (Objects.equals(vulnerabilityId, vulnerability.getId())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/VulnerabilityExclusionFilterTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/VulnerabilityExclusionFilterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.ossindex;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.sonatype.goodies.packageurl.PackageUrl;
+import org.sonatype.goodies.packageurl.PackageUrlBuilder;
+import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
+import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerability;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VulnerabilityExclusionFilterTest
+{
+  private static final PackageUrl PACKAGE_URL = new PackageUrlBuilder()
+      .type("maven")
+      .namespace("ns1")
+      .name("n1")
+      .version("b1")
+      .build();
+
+  private static final Set<String> VULNERABILITY_IDS = ImmutableSet.of("ABC-123");
+
+  private static final Set<PackageUrl> COORDINATES = ImmutableSet.of(PACKAGE_URL);
+
+  private Map<PackageUrl, ComponentReport> componentReportMap;
+
+  private ComponentReportVulnerability vulnerability1;
+
+  private ComponentReportVulnerability vulnerability2;
+
+  @Before
+  public void setup() throws Exception {
+    componentReportMap = new HashMap<>();
+    componentReportMap.put(PACKAGE_URL, setupComponentReport());
+  }
+
+  @Test
+  public void testApply_excludeByCoordinate() {
+    VulnerabilityExclusionFilter filter = new VulnerabilityExclusionFilter(Collections.emptySet(), COORDINATES);
+    filter.apply(componentReportMap);
+    assertThat(componentReportMap).doesNotContainKey(PACKAGE_URL);
+  }
+
+  @Test
+  public void testApply_excludeByVulnerabilityId() {
+    VulnerabilityExclusionFilter filter = new VulnerabilityExclusionFilter(VULNERABILITY_IDS, Collections.emptySet());
+    filter.apply(componentReportMap);
+
+    List<ComponentReportVulnerability> vulnerabilities = componentReportMap.get(PACKAGE_URL).getVulnerabilities();
+    assertThat(vulnerabilities).hasSize(1);
+    assertThat(vulnerabilities).doesNotContain(vulnerability1);
+    assertThat(vulnerabilities).contains(vulnerability2);
+  }
+
+  private ComponentReport setupComponentReport() throws Exception {
+    ComponentReport componentReport = new ComponentReport();
+    componentReport.setCoordinates(PACKAGE_URL);
+
+    vulnerability1 = new ComponentReportVulnerability();
+    vulnerability1.setId("ABC-123");
+    vulnerability1.setTitle("Title 1");
+    vulnerability1.setCvssScore(4f);
+    vulnerability1.setReference(new URI("http://test/123"));
+
+    vulnerability2 = new ComponentReportVulnerability();
+    vulnerability2.setId("DEF-456");
+    vulnerability2.setTitle("Title 2");
+    vulnerability2.setCvssScore(6f);
+    vulnerability2.setReference(new URI("http://test/456"));
+
+    componentReport.setVulnerabilities(Lists.newArrayList(vulnerability1, vulnerability2));
+    return componentReport;
+  }
+}

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/VulnerabilityExclusionFilterTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/VulnerabilityExclusionFilterTest.java
@@ -63,7 +63,9 @@ public class VulnerabilityExclusionFilterTest
   public void testApply_excludeByCoordinate() {
     VulnerabilityExclusionFilter filter = new VulnerabilityExclusionFilter(Collections.emptySet(), COORDINATES);
     filter.apply(componentReportMap);
-    assertThat(componentReportMap).doesNotContainKey(PACKAGE_URL);
+    assertThat(componentReportMap).containsKey(PACKAGE_URL);
+    List<ComponentReportVulnerability> vulnerabilities = componentReportMap.get(PACKAGE_URL).getVulnerabilities();
+    assertThat(vulnerabilities).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
Add support for excluding vulnerabilities. Vulnerabilities can by excluded by either 
- Vulnerability Id
- Coordinate e.g. exclude all vulnerabilities for this component.

**Note**
When excluding by coordinate, the coordinate must be an **exact** match. Also only vulnerabilities for the component will be excluded (not vulnerabilities for transitive components).

It relates to the following issue #s:
* Fixes #58 