### PR TITLE
Disable Jansi in in log configuration

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -18,7 +18,6 @@
 -->
 <configuration debug="false">
   <appender name="CONSOLE" class="shadow.ch.qos.logback.core.ConsoleAppender">
-    <withJansi>true</withJansi>
     <encoder>
       <pattern>%m%n</pattern>
     </encoder>


### PR DESCRIPTION
Remove jansi for from configuration. This prevents the ClassNotFoundException mentioned in #61, while still printing in colour. 

Tested on Windows 10 using Windows Terminal and Command prompt.

It relates to the following issue #s:
Fixes #61 

@guillermo-varela 
