### PR TITLE
Add dependencies to the scanned Module

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ group=org.sonatype.gradle.plugins
 version=2.0.3-SNAPSHOT
 release.useAutomaticVersion=true
 
-nexusJavaApiVersion=3.26
+nexusJavaApiVersion=3.27
 ossIndexClientVersion=1.3.0
 
 junitVersion=4.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ group=org.sonatype.gradle.plugins
 version=2.0.3-SNAPSHOT
 release.useAutomaticVersion=true
 
-nexusJavaApiVersion=3.17
+nexusJavaApiVersion=3.26
 ossIndexClientVersion=1.3.0
 
 junitVersion=4.13

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -163,6 +163,17 @@ public class DependenciesFinder
     }
   }
 
+  @VisibleForTesting
+  Dependency processDependency(ResolvedDependency resolvedDependency, boolean isDirect) {
+    Dependency dependency = new Dependency()
+            .setId(resolvedDependency.getName())
+            .setDirect(isDirect);
+    resolvedDependency.getChildren().forEach(child -> {
+      dependency.addDependency(processDependency(child, false));
+    });
+    return dependency;
+  }
+
   private boolean isAcceptableConfiguration(Configuration configuration, boolean allConfigurations) {
     if (configuration.getName().endsWith(COPY_CONFIGURATION_NAME))
       return false;
@@ -172,15 +183,5 @@ public class DependenciesFinder
     return configuration.isCanBeResolved() && (CONFIGURATION_NAMES.contains(configuration.getName())
         || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_COMPILE_LEGACY_CONFIGURATION_NAME)
         || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_COMPILE_CONFIGURATION_NAME));
-  }
-
-  private Dependency processDependency(ResolvedDependency resolvedDependency, boolean isDirect) {
-    Dependency dependency = new Dependency()
-        .setId(resolvedDependency.getName())
-        .setDirect(isDirect);
-    resolvedDependency.getChildren().forEach(child -> {
-      dependency.addDependency(processDependency(child, false));
-    });
-    return dependency;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -88,9 +88,9 @@ public class DependenciesFinder
         module.addConsumedArtifact(artifact);
       });
 
-      findResolvedDependencies(project, allConfigurations).forEach(resolvedDependency -> {
-        module.addDependency(processDependency(resolvedDependency, true));
-      });
+      findResolvedDependencies(project, allConfigurations).forEach(resolvedDependency ->
+        module.addDependency(processDependency(resolvedDependency, true))
+      );
 
       modules.add(module);
     });
@@ -168,9 +168,7 @@ public class DependenciesFinder
     Dependency dependency = new Dependency()
             .setId(resolvedDependency.getName())
             .setDirect(isDirect);
-    resolvedDependency.getChildren().forEach(child -> {
-      dependency.addDependency(processDependency(child, false));
-    });
+    resolvedDependency.getChildren().forEach(child -> dependency.addDependency(processDependency(child, false)));
     return dependency;
   }
 

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -357,7 +357,7 @@ public class DependenciesFinderTest
     Dependency subChild = child2.getDependencies().get(0);
     assertThat(subChild.isDirect()).isFalse();
     assertThat(subChild.getId()).isEqualTo("g4:a4:v4");
-    assertThat(subChild.getDependencies()).hasSize(1);
+    assertThat(subChild.getDependencies()).isEmpty();
   }
 
   private Project buildProject(String configurationName, boolean needToCreateConfiguration) {


### PR DESCRIPTION
When the dependencies list is present in the module, a `<dependencies>` entry is added in the scan XML file generated by IQ libraries:

```XML
<dependencies>
  <dep id="org.apache.commons:commons-math3:3.6.1" direct="true"/>
  <dep id="com.google.guava:guava:27.0.1-jre" direct="true"/>
  <dep id="org.springframework.boot:spring-boot-starter-web:1.0.0.RELEASE" direct="true">
    <dep id="org.springframework.boot:spring-boot-autoconfigure:1.0.0.RELEASE"/>
    ...
  </dep>
</dependencies>
```

## Setup for demo
- A Gradle project `gradle-producer` was scanned using IQ with lots of dependencies (acts as the InnerSource producer).
- A Gradle project `gradle-consumer` depends on `gradle-producer` directly and contains another direct dependency `com.squareup.retrofit2 : retrofit : 2.9.0` (which brings two transitive dependencies).

## Scanning `gradle-consumer` before this PR
<img width="1142" alt="Screen Shot 2021-02-18 at 10 01 28 PM" src="https://user-images.githubusercontent.com/10326286/108451687-3ef4dd00-7235-11eb-9276-58fce0e0d501.png">

`gradle-producer` is shown as an **unknown** component and all transitive dependencies are blended together.

## Scanning `gradle-consumer` after this PR
<img width="1142" alt="Screen Shot 2021-02-18 at 10 02 47 PM" src="https://user-images.githubusercontent.com/10326286/108451621-2389d200-7235-11eb-826f-98f5273bca7b.png">

`gradle-producer` is shown as a **known** InnerSource component and the transitive dependencies it brings are grouped below this component to differentiate them from the ones related to `gradle-consumer`.

cc @bhamail / @DarthHater  / @shaikhu