### PR TITLE
Apply Groovy Exclusions

### DIFF
--- a/nexus-platform-api/build.gradle
+++ b/nexus-platform-api/build.gradle
@@ -14,6 +14,11 @@ shadowJar {
   mergeServiceFiles()
   classifier = null
 
+  exclude 'groovy/**'
+  exclude 'groovyjarjarantlr/**'
+  exclude 'groovyjarjarasm/**'
+  exclude 'groovyjarjarcommonscli/**'
+
   def prefix = 'nexus.shadow.'
   relocate('com.', "${prefix}com.") {
     exclude 'com.sonatype.**'


### PR DESCRIPTION
Release 2.0.4  of the plugin used a later version of the nexus-java-api, which didn't obfuscate groovy dependencies. Applying these exclusions results in successful scans using the example `ossIndexAudit ` configuration mentioned in the ticket.

It relates to the following issue #s:
* Fixes #68 
