### PR TITLE
CLM-18313 Builds the artifact ID for InnerSource dependency manually

### DIFF
--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -32,6 +32,7 @@ import com.sonatype.insight.scan.module.model.Module;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedArtifact;
@@ -83,8 +84,13 @@ public class DependenciesFinder
       Module module = buildModule(project);
 
       findResolvedArtifacts(project, allConfigurations).forEach(resolvedArtifact -> {
-        Artifact artifact = new Artifact().setId(resolvedArtifact.getId().getComponentIdentifier().getDisplayName())
-            .setPathname(resolvedArtifact.getFile()).setMonitored(true);
+        ModuleVersionIdentifier artifactId = resolvedArtifact.getModuleVersion().getId();
+
+        Artifact artifact = new Artifact()
+            .setId(artifactId.getGroup() + ":" + artifactId.getName() + ":" + artifactId.getVersion())
+            .setPathname(resolvedArtifact.getFile())
+            .setMonitored(true);
+
         module.addConsumedArtifact(artifact);
       });
 


### PR DESCRIPTION
A Nexus IQ customer is having troubles having InnerSource working properly. After analyzing the files shared by the customer we see the "artifact ID" has a colon (:) in the version fragment for SNAPSHOT dependencies.

By manually building this ID the idea is to avoid any extra characters that a might be introduce in the display name of a component identifier by Gradle.

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu