### PR TITLE
CLM-18367 Include runtime dependencies as the IQ Maven plugin does

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Gradle can be used to build projects developed in various programming languages.
 - Edit its `build.gradle` file adding this:
 ```
 plugins {
-  id 'org.sonatype.gradle.plugins.scan' version '2.0.6' // Update the version as needed
+  id 'org.sonatype.gradle.plugins.scan' version '2.0.9' // Update the version as needed
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ on this plugin. Cache can also be configured optionally.
 ossIndexAudit {
     username = 'email' // if not provided, an anonymous query will be made
     password = 'pass'
-    allConfigurations = true // if true includes the dependencies in all resolvable configurations. By default is false, meaning only 'compileClasspath' and 'releaseCompileClasspath' are considered
+    allConfigurations = true // if true includes the dependencies in all resolvable configurations. By default is false, meaning only 'compileClasspath', 'runtimeClasspath', 'releaseCompileClasspath' and 'releaseRuntimeClasspath' are considered
     useCache = true // true by default
     cacheDirectory = 'some/path' // by default it uses the user data directory (according to OS)
     cacheExpiration = 'PT12H' // 12 hours if omitted. It must follow the Joda Time specification at https://www.javadoc.io/doc/joda-time/joda-time/2.10.4/org/joda/time/Duration.html#parse-java.lang.String-
@@ -106,7 +106,7 @@ nexusIQScan {
     serverUrl = 'http://localhost:8070'
     applicationId = 'app'
     stage = 'build' // build is used if omitted
-    allConfigurations = true // if true includes the dependencies in all resolvable configurations. By default is false, meaning only 'compileClasspath' and 'releaseCompileClasspath' are considered
+    allConfigurations = true // if true includes the dependencies in all resolvable configurations. By default is false, meaning only 'compileClasspath', 'runtimeClasspath', 'releaseCompileClasspath' and 'releaseRuntimeClasspath' are considered
     resultFilePath = 'results.json' // Optional. JSON file containing results of the evaluation
 }
 ```

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -51,6 +51,8 @@ public class DependenciesFinder
 
   private static final String RELEASE_RUNTIME_APK_LEGACY_CONFIGURATION_NAME = "_releaseApk";
 
+  private static final String RELEASE_RUNTIME_LIBRARY_LEGACY_CONFIGURATION_NAME = "_releasePublish";
+
   private static final String RELEASE_COMPILE_CONFIGURATION_NAME = "releaseCompileClasspath";
 
   private static final String RELEASE_RUNTIME_CONFIGURATION_NAME = "releaseRuntimeClasspath";
@@ -61,6 +63,7 @@ public class DependenciesFinder
           RUNTIME_CLASSPATH_CONFIGURATION_NAME,
           RELEASE_COMPILE_LEGACY_CONFIGURATION_NAME,
           RELEASE_RUNTIME_APK_LEGACY_CONFIGURATION_NAME,
+          RELEASE_RUNTIME_LIBRARY_LEGACY_CONFIGURATION_NAME,
           RELEASE_COMPILE_CONFIGURATION_NAME,
           RELEASE_RUNTIME_CONFIGURATION_NAME));
 
@@ -195,6 +198,7 @@ public class DependenciesFinder
     return configuration.isCanBeResolved() && (CONFIGURATION_NAMES.contains(configuration.getName())
         || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_COMPILE_LEGACY_CONFIGURATION_NAME)
         || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_RUNTIME_APK_LEGACY_CONFIGURATION_NAME)
+        || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_RUNTIME_LIBRARY_LEGACY_CONFIGURATION_NAME)
         || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_COMPILE_CONFIGURATION_NAME)
         || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_RUNTIME_CONFIGURATION_NAME));
   }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -43,18 +43,26 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting;
 
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME;
+import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME;
 
 public class DependenciesFinder
 {
   private static final String RELEASE_COMPILE_LEGACY_CONFIGURATION_NAME = "_releaseCompile";
 
+  private static final String RELEASE_RUNTIME_APK_LEGACY_CONFIGURATION_NAME = "_releaseApk";
+
   private static final String RELEASE_COMPILE_CONFIGURATION_NAME = "releaseCompileClasspath";
+
+  private static final String RELEASE_RUNTIME_CONFIGURATION_NAME = "releaseRuntimeClasspath";
 
   private static final Set<String> CONFIGURATION_NAMES =
       new HashSet<>(Arrays.asList(
           COMPILE_CLASSPATH_CONFIGURATION_NAME,
+          RUNTIME_CLASSPATH_CONFIGURATION_NAME,
           RELEASE_COMPILE_LEGACY_CONFIGURATION_NAME,
-          RELEASE_COMPILE_CONFIGURATION_NAME));
+          RELEASE_RUNTIME_APK_LEGACY_CONFIGURATION_NAME,
+          RELEASE_COMPILE_CONFIGURATION_NAME,
+          RELEASE_RUNTIME_CONFIGURATION_NAME));
 
   private static final String COPY_CONFIGURATION_NAME = "sonatypeCopyConfiguration";
 
@@ -186,6 +194,8 @@ public class DependenciesFinder
     }
     return configuration.isCanBeResolved() && (CONFIGURATION_NAMES.contains(configuration.getName())
         || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_COMPILE_LEGACY_CONFIGURATION_NAME)
-        || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_COMPILE_CONFIGURATION_NAME));
+        || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_RUNTIME_APK_LEGACY_CONFIGURATION_NAME)
+        || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_COMPILE_CONFIGURATION_NAME)
+        || StringUtils.endsWithIgnoreCase(configuration.getName(), RELEASE_RUNTIME_CONFIGURATION_NAME));
   }
 }

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME;
+import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -60,29 +61,64 @@ public class DependenciesFinderTest
   }
 
   @Test
-  public void testFindResolvedDependencies_includeLegacyAndroidDependencies() {
+  public void testFindResolvedDependencies_includeRuntimeDependencies() {
+    Project project = buildProject(RUNTIME_CLASSPATH_CONFIGURATION_NAME, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
+  public void testFindResolvedDependencies_includeLegacyCompileAndroidDependencies() {
     Project project = buildProject("_releaseCompile", true);
     Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
     assertThat(result).hasSize(1);
   }
 
   @Test
-  public void testFindResolvedDependencies_includeAndroidDependencies() {
+  public void testFindResolvedDependencies_includeLegacyRuntimeApkAndroidDependencies() {
+    Project project = buildProject("_releaseApk", true);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
+  public void testFindResolvedDependencies_includeCompileAndroidDependencies() {
     Project project = buildProject("releaseCompileClasspath", true);
     Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
     assertThat(result).hasSize(1);
   }
 
   @Test
-  public void testFindResolvedDependencies_includeLegacyAndroidDependenciesUsingVariant() {
+  public void testFindResolvedDependencies_includeRuntimeAndroidDependencies() {
+    Project project = buildProject("releaseRuntimeClasspath", true);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
+  public void testFindResolvedDependencies_includeLegacyCompileApkAndroidDependenciesUsingVariant() {
     Project project = buildProject("variantProd_ReleaseCompile", true);
     Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
     assertThat(result).hasSize(1);
   }
 
   @Test
-  public void testFindResolvedDependencies_includeAndroidDependenciesUsingVariant() {
+  public void testFindResolvedDependencies_includeLegacyRuntimeApkAndroidDependenciesUsingVariant() {
+    Project project = buildProject("variantProd_ReleaseApk", true);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
+  public void testFindResolvedDependencies_includeAndroidCompileDependenciesUsingVariant() {
     Project project = buildProject("variantProdReleaseCompileClasspath", true);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
+  public void testFindResolvedDependencies_includeAndroidRuntimeDependenciesUsingVariant() {
+    Project project = buildProject("variantProdReleaseRuntimeClasspath", true);
     Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
     assertThat(result).hasSize(1);
   }
@@ -109,8 +145,22 @@ public class DependenciesFinderTest
   }
 
   @Test
-  public void testFindResolvedArtifacts_includeAndroidDependencies() {
+  public void testFindResolvedArtifacts_includeRuntimeDependencies() {
+    Project project = buildProject(RUNTIME_CLASSPATH_CONFIGURATION_NAME, false);
+    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false);
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
+  public void testFindResolvedArtifacts_includeAndroidCompileDependencies() {
     Project project = buildProject("releaseCompileClasspath", true);
+    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false);
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
+  public void testFindResolvedArtifacts_includeAndroidRuntimeDependencies() {
+    Project project = buildProject("releaseRuntimeClasspath", true);
     Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false);
     assertThat(result).hasSize(1);
   }

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -82,6 +82,13 @@ public class DependenciesFinderTest
   }
 
   @Test
+  public void testFindResolvedDependencies_includeLegacyRuntimeLibraryAndroidDependencies() {
+    Project project = buildProject("_releasePublish", true);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
   public void testFindResolvedDependencies_includeCompileAndroidDependencies() {
     Project project = buildProject("releaseCompileClasspath", true);
     Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
@@ -105,6 +112,13 @@ public class DependenciesFinderTest
   @Test
   public void testFindResolvedDependencies_includeLegacyRuntimeApkAndroidDependenciesUsingVariant() {
     Project project = buildProject("variantProd_ReleaseApk", true);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    assertThat(result).hasSize(1);
+  }
+
+  @Test
+  public void testFindResolvedDependencies_includeLegacyRuntimeLibraryAndroidDependenciesUsingVariant() {
+    Project project = buildProject("variantProd_ReleasePublish", true);
     Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
     assertThat(result).hasSize(1);
   }


### PR DESCRIPTION
Same as the [Sonatype CLM for Maven](https://help.sonatype.com/integrations/sonatype-clm-for-maven), the Gradle plugin will include both compile and runtime dependencies.

There are differences between "api" and "implementation" configurations: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation

Let's say we have "Project A" with two dependencies:
```
Project A
 -> Dependency 1 (api)
 -> Dependency 2 (implementation)
```

And then we have "Project B" which depends on "Project A":
```
Project B
 -> Project A
    -> Dependency 1
```

Project B only gets "Dependency 1" on its classpath to compile, so it's available to be used during development, while "Dependency 2" cannot be imported into any code of "Project B" (the **implementation** configuration means "Dependency 2" is meant just to develop at Project A so it's not exported as transitive dependency).

But, when releasing/packaging/deploying Project B "Dependency 2" is still found in the final output.

With this PR, an evaluation report in Nexus IQ and the output for OSS Index for Project B will include "Dependency 2".

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
