### PR TITLE
Bug Fix - Scanning circular dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,8 +78,7 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  //implementation files ("nexus-platform-api/build/libs/nexus-platform-api-${version}.jar")
-  implementation "com.sonatype.nexus:nexus-platform-api:$nexusPlatformApiVersion:internal"
+  implementation files ("nexus-platform-api/build/libs/nexus-platform-api-${version}.jar")
   implementation "org.sonatype.ossindex:ossindex-service-client:$ossIndexClientVersion"
 
   testImplementation gradleTestKit()

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,8 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation files ("nexus-platform-api/build/libs/nexus-platform-api-${version}.jar")
+  //implementation files ("nexus-platform-api/build/libs/nexus-platform-api-${version}.jar")
+  implementation "com.sonatype.nexus:nexus-platform-api:$nexusPlatformApiVersion:internal"
   implementation "org.sonatype.ossindex:ossindex-service-client:$ossIndexClientVersion"
 
   testImplementation gradleTestKit()

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ group=org.sonatype.gradle.plugins
 version=2.0.11-SNAPSHOT
 release.useAutomaticVersion=true
 
-nexusPlatformApiVersion=3.32
+nexusPlatformApiVersion=3.37
 ossIndexClientVersion=1.7.0
 
 junitVersion=4.13.2

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -106,7 +106,7 @@ public class DependenciesFinder
       });
 
       findResolvedDependencies(project, allConfigurations).forEach(resolvedDependency ->
-        module.addDependency(processDependency(resolvedDependency, true))
+        module.addDependency(processDependency(resolvedDependency, true, new HashSet<>()))
       );
 
       modules.add(module);
@@ -181,11 +181,20 @@ public class DependenciesFinder
   }
 
   @VisibleForTesting
-  Dependency processDependency(ResolvedDependency resolvedDependency, boolean isDirect) {
+  Dependency processDependency(
+      ResolvedDependency resolvedDependency,
+      boolean isDirect,
+      Set<String> processedDependencies)
+  {
     Dependency dependency = new Dependency()
-            .setId(resolvedDependency.getName())
-            .setDirect(isDirect);
-    resolvedDependency.getChildren().forEach(child -> dependency.addDependency(processDependency(child, false)));
+        .setId(resolvedDependency.getName())
+        .setDirect(isDirect);
+    processedDependencies.add(resolvedDependency.getName());
+    resolvedDependency.getChildren().forEach(child -> {
+      if (!processedDependencies.contains(child.getName())) {
+        dependency.addDependency(processDependency(child, false, processedDependencies));
+      }
+    });
     return dependency;
   }
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -189,12 +189,26 @@ public class DependenciesFinder
     Dependency dependency = new Dependency()
         .setId(resolvedDependency.getName())
         .setDirect(isDirect);
-    processedDependencies.add(resolvedDependency.getName());
+
     resolvedDependency.getChildren().forEach(child -> {
-      if (!processedDependencies.contains(child.getName())) {
+      if (processedDependencies.add(child.getName())) {
         dependency.addDependency(processDependency(child, false, processedDependencies));
       }
+      else {
+        Dependency childDependency = new Dependency()
+            .setId(child.getName())
+            .setDirect(false);
+
+        child.getChildren().forEach(grandchild -> {
+          childDependency.addDependency(new Dependency()
+              .setId(grandchild.getName())
+              .setDirect(false));
+        });
+
+        dependency.addDependency(childDependency);
+      }
     });
+
     return dependency;
   }
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
@@ -105,7 +105,7 @@ public class NexusIqScanTask
         List<Module> modules = dependenciesFinder.findModules(getProject(), extension.isAllConfigurations());
 
         ScanResult scanResult = iqClient.scan(extension.getApplicationId(), proprietaryConfig, new Properties(),
-            Collections.emptyList(), scanFolder, Collections.emptyMap(), modules);
+            Collections.emptyList(), scanFolder, Collections.emptyMap(), Collections.emptySet(), modules);
 
         File jsonResultsFile = null;
         if (StringUtils.isNotBlank(extension.getResultFilePath())) {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -152,15 +152,12 @@ public class OssIndexAuditTask
     return map;
   }
 
-  private void buildDependenciesMap(
-      ResolvedDependency dependency,
-      BiMap<ResolvedDependency, PackageUrl> mapAccumulator)
-  {
+  @VisibleForTesting
+  void buildDependenciesMap(ResolvedDependency dependency, BiMap<ResolvedDependency, PackageUrl> mapAccumulator) {
     mapAccumulator.forcePut(dependency, toPackageUrl(dependency));
 
     dependency.getChildren().forEach(child -> {
-      mapAccumulator.forcePut(child, toPackageUrl(child));
-      if (!mapAccumulator.containsKey(child)) {
+      if (mapAccumulator.forcePut(child, toPackageUrl(child)) == null) {
         buildDependenciesMap(child, mapAccumulator);
       }
     });

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -160,7 +160,9 @@ public class OssIndexAuditTask
 
     dependency.getChildren().forEach(child -> {
       mapAccumulator.forcePut(child, toPackageUrl(child));
-      buildDependenciesMap(child, mapAccumulator);
+      if (!mapAccumulator.containsKey(child)) {
+        buildDependenciesMap(child, mapAccumulator);
+      }
     });
   }
 

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -390,32 +390,45 @@ public class DependenciesFinderTest
 
   @Test
   public void testProcessDependency() {
+    testProcessDependency(false);
+  }
+
+  @Test
+  public void testProcessDependency_avoidCircularDependenciesStackOverflowError() {
+    testProcessDependency(true);
+  }
+
+  private void testProcessDependency(boolean setupCircularDependencies) {
     ModuleVersionIdentifier parentModuleVersionIdentifier = DefaultModuleVersionIdentifier.newId("g", "a", "v");
     ResolvedConfigurationIdentifier parentResolvedConfigurationIdentifier = new ResolvedConfigurationIdentifier(
-            parentModuleVersionIdentifier, "");
+        parentModuleVersionIdentifier, "");
     DefaultResolvedDependency parentDependency = new DefaultResolvedDependency(
-            parentResolvedConfigurationIdentifier, null);
+        parentResolvedConfigurationIdentifier, null);
 
     ModuleVersionIdentifier singleChildModuleVersionIdentifier = DefaultModuleVersionIdentifier.newId(
-            "g2", "a2", "v2");
+        "g2", "a2", "v2");
     ResolvedConfigurationIdentifier singleChildResolvedConfigurationIdentifier = new ResolvedConfigurationIdentifier(
-            singleChildModuleVersionIdentifier, "");
+        singleChildModuleVersionIdentifier, "");
     DefaultResolvedDependency singleChildDependency = new DefaultResolvedDependency(
-            singleChildResolvedConfigurationIdentifier, null);
+        singleChildResolvedConfigurationIdentifier, null);
 
     ModuleVersionIdentifier multiChildModuleVersionIdentifier = DefaultModuleVersionIdentifier.newId("g3", "a3", "v3");
     ResolvedConfigurationIdentifier multiChildResolvedConfigurationIdentifier = new ResolvedConfigurationIdentifier(
-            multiChildModuleVersionIdentifier, "");
+        multiChildModuleVersionIdentifier, "");
     DefaultResolvedDependency multiChildDependency = new DefaultResolvedDependency(
-            multiChildResolvedConfigurationIdentifier, null);
+        multiChildResolvedConfigurationIdentifier, null);
 
     ModuleVersionIdentifier subChildModuleVersionIdentifier = DefaultModuleVersionIdentifier.newId("g4", "a4", "v4");
     ResolvedConfigurationIdentifier subChildResolvedConfigurationIdentifier = new ResolvedConfigurationIdentifier(
-            subChildModuleVersionIdentifier, "");
+        subChildModuleVersionIdentifier, "");
     DefaultResolvedDependency subChildDependency = new DefaultResolvedDependency(
-            subChildResolvedConfigurationIdentifier, null);
+        subChildResolvedConfigurationIdentifier, null);
 
     multiChildDependency.addChild(subChildDependency);
+
+    if (setupCircularDependencies) {
+      singleChildDependency.addChild(parentDependency);
+    }
 
     parentDependency.addChild(singleChildDependency);
     parentDependency.addChild(multiChildDependency);

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -442,17 +442,27 @@ public class DependenciesFinderTest
     Dependency child1 = dependency.getDependencies().get(0);
     assertThat(child1.isDirect()).isFalse();
     assertThat(child1.getId()).isEqualTo("g2:a2:v2");
-    assertThat(child1.getDependencies()).isEmpty();
+
+    if (!setupCircularDependencies) {
+      assertThat(child1.getDependencies()).isEmpty();
+    }
+      else {
+      assertThat(child1.getDependencies()).hasSize(1);
+      Dependency subChild1 = child1.getDependencies().get(0);
+      assertThat(subChild1.isDirect()).isFalse();
+      assertThat(subChild1.getId()).isEqualTo("g:a:v");
+      assertThat(subChild1.getDependencies()).hasSize(2);
+    }
 
     Dependency child2 = dependency.getDependencies().get(1);
     assertThat(child2.isDirect()).isFalse();
     assertThat(child2.getId()).isEqualTo("g3:a3:v3");
     assertThat(child2.getDependencies()).hasSize(1);
 
-    Dependency subChild = child2.getDependencies().get(0);
-    assertThat(subChild.isDirect()).isFalse();
-    assertThat(subChild.getId()).isEqualTo("g4:a4:v4");
-    assertThat(subChild.getDependencies()).isEmpty();
+    Dependency subChild2 = child2.getDependencies().get(0);
+    assertThat(subChild2.isDirect()).isFalse();
+    assertThat(subChild2.getId()).isEqualTo("g4:a4:v4");
+    assertThat(subChild2.getDependencies()).isEmpty();
   }
 
   private Project buildProject(String configurationName, boolean needToCreateConfiguration) {

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -442,17 +442,7 @@ public class DependenciesFinderTest
     Dependency child1 = dependency.getDependencies().get(0);
     assertThat(child1.isDirect()).isFalse();
     assertThat(child1.getId()).isEqualTo("g2:a2:v2");
-
-    if (!setupCircularDependencies) {
-      assertThat(child1.getDependencies()).isEmpty();
-    }
-      else {
-      assertThat(child1.getDependencies()).hasSize(1);
-      Dependency subChild1 = child1.getDependencies().get(0);
-      assertThat(subChild1.isDirect()).isFalse();
-      assertThat(subChild1.getId()).isEqualTo("g:a:v");
-      assertThat(subChild1.getDependencies()).hasSize(2);
-    }
+    assertThat(child1.getDependencies()).isEmpty();
 
     Dependency child2 = dependency.getDependencies().get(1);
     assertThat(child2.isDirect()).isFalse();

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -15,6 +15,7 @@
  */
 package org.sonatype.gradle.plugins.scan.common;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -419,7 +420,7 @@ public class DependenciesFinderTest
     parentDependency.addChild(singleChildDependency);
     parentDependency.addChild(multiChildDependency);
 
-    Dependency dependency = finder.processDependency(parentDependency, true);
+    Dependency dependency = finder.processDependency(parentDependency, true, new HashSet<>());
     assertThat(dependency).isNotNull();
     assertThat(dependency.isDirect()).isTrue();
     assertThat(dependency.getId()).isEqualTo("g:a:v");


### PR DESCRIPTION
Tested using a dependency (`org.apache.xmlgraphics:batik-transcoder:1.7`) which contains circular dependencies. Was able to produce report. Will leave in draft for further testing.

It relates to the following issue #s:
* Fixes #76 

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
