### PR TITLE
Copies Gradle configurations to another Set so more can be added

### DIFF
--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -73,7 +73,7 @@ public class DependenciesFinder
 
   public Set<ResolvedDependency> findResolvedDependencies(Project rootProject, boolean allConfigurations) {
     return new LinkedHashSet<>(rootProject.getAllprojects()).stream()
-        .flatMap(project -> project.getConfigurations().stream())
+        .flatMap(project -> new LinkedHashSet<>(project.getConfigurations()).stream())
         .filter(configuration -> isAcceptableConfiguration(configuration, allConfigurations))
         .flatMap(configuration -> getDependencies(rootProject, configuration,
             resolvedConfiguration -> resolvedConfiguration.getFirstLevelModuleDependencies().stream()))


### PR DESCRIPTION
When resolving the dependencies from a Gradle configuration throws a `ResolveException` a new resolvable configuration is created and dependencies are copied there.

As the code iterates over a Set of configuration, this change creates a copy of the original Set so it can be iterated without considering the copies and without throwing `ConcurrentModificationException`.

It relates to the following issue #s:
* Fixes #74

cc @bhamail / @DarthHater / @shaikhu
