### PR TITLE
#80 Allows to set directories to include and exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ nexusIQScan {
     allConfigurations = false // if true includes the dependencies in all resolvable configurations. By default is false, meaning only 'compileClasspath', 'runtimeClasspath', 'releaseCompileClasspath' and 'releaseRuntimeClasspath' are considered
     resultFilePath = 'results.json' // Optional. JSON file containing results of the evaluation
     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
-    dirIncludes = 'some-ant-pattern' // Optional. Ant-like glob patterns to select directories/archives that should be examined
-    dirExcludes = 'some-ant-pattern' // Optional. Ant-like glob patterns to select directories/archives that should be excluded. For Android we suggest using '**/classes.jar,**/annotations.zip,**/lint.jar'
+    dirExcludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using '**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar'
+    dirIncludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
 }
 ```
 - Open Terminal on the project's root and run `./gradlew nexusIQScan`

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ nexusIQScan {
     allConfigurations = false // if true includes the dependencies in all resolvable configurations. By default is false, meaning only 'compileClasspath', 'runtimeClasspath', 'releaseCompileClasspath' and 'releaseRuntimeClasspath' are considered
     resultFilePath = 'results.json' // Optional. JSON file containing results of the evaluation
     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
+    dirIncludes = 'some-ant-pattern' // Optional. Ant-like glob patterns to select directories/archives that should be examined
+    dirExcludes = 'some-ant-pattern' // Optional. Ant-like glob patterns to select directories/archives that should be excluded. For Android we suggest using '**/classes.jar,**/annotations.zip,**/lint.jar'
 }
 ```
 - Open Terminal on the project's root and run `./gradlew nexusIQScan`

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 group=org.sonatype.gradle.plugins
-version=2.0.13-SNAPSHOT
+version=2.1.0-SNAPSHOT
 release.useAutomaticVersion=true
 
 nexusPlatformApiVersion=3.37

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqPluginExtension.java
@@ -47,12 +47,18 @@ public class NexusIqPluginExtension
 
   private Set<String> modulesExcluded;
 
+  private String dirIncludes;
+
+  private String dirExcludes;
+
   public NexusIqPluginExtension(Project project) {
     stage = Stage.ID_BUILD;
     simulationEnabled = false;
     simulatedPolicyActionId = PolicyAction.NONE.toString();
     scanFolderPath = project.getBuildDir() + "/sonatype-clm/";
     modulesExcluded = Collections.emptySet();
+    dirIncludes = "";
+    dirExcludes = "";
   }
 
   public String getUsername() {
@@ -142,5 +148,21 @@ public class NexusIqPluginExtension
 
   public void setModulesExcluded(Set<String> modulesExcluded) {
     this.modulesExcluded = modulesExcluded;
+  }
+
+  public String getDirIncludes() {
+    return dirIncludes;
+  }
+
+  public void setDirIncludes(String dirIncludes) {
+    this.dirIncludes = dirIncludes;
+  }
+
+  public String getDirExcludes() {
+    return dirExcludes;
+  }
+
+  public void setDirExcludes(String dirExcludes) {
+    this.dirExcludes = dirExcludes;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
@@ -133,8 +133,10 @@ public class NexusIqScanTask
 
   private Properties buildProperties() {
     Properties properties = new Properties();
-    if (!StringUtils.isAllBlank(extension.getDirIncludes(), extension.getDirExcludes())) {
+    if (StringUtils.isNotBlank(extension.getDirIncludes())) {
       properties.setProperty("dirIncludes", extension.getDirIncludes());
+    }
+    if (StringUtils.isNotBlank(extension.getDirExcludes())) {
       properties.setProperty("dirExcludes", extension.getDirExcludes());
     }
     return properties;

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
@@ -110,7 +110,7 @@ public class NexusIqScanTask
         List<Module> modules = dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(),
             extension.getModulesExcluded());
 
-        ScanResult scanResult = iqClient.scan(extension.getApplicationId(), proprietaryConfig, new Properties(),
+        ScanResult scanResult = iqClient.scan(extension.getApplicationId(), proprietaryConfig, buildProperties(),
             Collections.emptyList(), scanFolder, Collections.emptyMap(), Collections.emptySet(), modules);
 
         File jsonResultsFile = null;
@@ -129,6 +129,15 @@ public class NexusIqScanTask
     catch (Exception e) {
       throw new GradleException("Could not scan the project: " + e.getMessage(), e);
     }
+  }
+
+  private Properties buildProperties() {
+    Properties properties = new Properties();
+    if (!StringUtils.isAllBlank(extension.getDirIncludes(), extension.getDirExcludes())) {
+      properties.setProperty("dirIncludes", extension.getDirIncludes());
+      properties.setProperty("dirExcludes", extension.getDirExcludes());
+    }
+    return properties;
   }
 
   private void logReport(PolicyAction policyAction, ApplicationPolicyEvaluation applicationPolicyEvaluation) {
@@ -216,6 +225,16 @@ public class NexusIqScanTask
   @Input
   public Set<String> getModulesExcluded() {
     return extension.getModulesExcluded();
+  }
+
+  @Input
+  public String getDirIncludes() {
+    return extension.getDirIncludes();
+  }
+
+  @Input
+  public String getDirExcludes() {
+    return extension.getDirExcludes();
   }
 
   @VisibleForTesting

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTaskTest.java
@@ -143,8 +143,8 @@ public class NexusIqScanTaskTest
   }
 
   @Test
-  public void testScan_realWithDirIncludesAndExcludes() throws Exception {
-    NexusIqScanTask task = buildScanTask(false, null, "dir-include", "dir-exclude");
+  public void testScan_realWithDirIncludes() throws Exception {
+    NexusIqScanTask task = buildScanTask(false, null, "dir-include", null);
     task.setDependenciesFinder(dependenciesFinderMock);
     when(iqClientMock.verifyOrCreateApplication(eq(task.getApplicationId()))).thenReturn(true);
 
@@ -152,6 +152,21 @@ public class NexusIqScanTaskTest
 
     Properties expected = new Properties();
     expected.setProperty("dirIncludes", task.getDirIncludes());
+
+    verify(iqClientMock).scan(eq(task.getApplicationId()), nullable(ProprietaryConfig.class), eq(expected), anyList(),
+        any(File.class), anyMap(), anySet(), anyList());
+
+  }
+
+  @Test
+  public void testScan_realWithDirExcludes() throws Exception {
+    NexusIqScanTask task = buildScanTask(false, null, null, "dir-exclude");
+    task.setDependenciesFinder(dependenciesFinderMock);
+    when(iqClientMock.verifyOrCreateApplication(eq(task.getApplicationId()))).thenReturn(true);
+
+    task.scan();
+
+    Properties expected = new Properties();
     expected.setProperty("dirExcludes", task.getDirExcludes());
 
     verify(iqClientMock).scan(eq(task.getApplicationId()), nullable(ProprietaryConfig.class), eq(expected), anyList(),


### PR DESCRIPTION
Allows to set directories to include and exclude in Nexus IQ.

Evaluation reports will have less noise when setting `dirExcludes = '**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar'` by excluding those files that are marked as unknown:

<img width="480" alt="Screen Shot 2021-07-22 at 1 01 48 PM" src="https://user-images.githubusercontent.com/10326286/126686979-e0a93f26-88eb-4a88-96d4-b9e66402a8e0.png">


It relates to the following issue #s:
* Fixes #80 

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
