### PR TITLE
#81 Exclude sub-modules by name for Nexus IQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ nexusIQScan {
     stage = 'build' // build is used if omitted
     allConfigurations = false // if true includes the dependencies in all resolvable configurations. By default is false, meaning only 'compileClasspath', 'runtimeClasspath', 'releaseCompileClasspath' and 'releaseRuntimeClasspath' are considered
     resultFilePath = 'results.json' // Optional. JSON file containing results of the evaluation
+    modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules that are not wanted to be scanned and evaluated.
 }
 ```
 - Open Terminal on the project's root and run `./gradlew nexusIQScan`

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ nexusIQScan {
     stage = 'build' // build is used if omitted
     allConfigurations = false // if true includes the dependencies in all resolvable configurations. By default is false, meaning only 'compileClasspath', 'runtimeClasspath', 'releaseCompileClasspath' and 'releaseRuntimeClasspath' are considered
     resultFilePath = 'results.json' // Optional. JSON file containing results of the evaluation
-    modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules that are not wanted to be scanned and evaluated.
+    modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
 }
 ```
 - Open Terminal on the project's root and run `./gradlew nexusIQScan`

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -88,28 +88,30 @@ public class DependenciesFinder
         .collect(Collectors.toSet());
   }
 
-  public List<Module> findModules(Project rootProject, boolean allConfigurations) {
+  public List<Module> findModules(Project rootProject, boolean allConfigurations, List<String> modulesExcluded) {
     List<Module> modules = new ArrayList<>();
 
     rootProject.allprojects(project -> {
-      Module module = buildModule(project);
+      if (!modulesExcluded.contains(project.getName())) {
+        Module module = buildModule(project);
 
-      findResolvedArtifacts(project, allConfigurations).forEach(resolvedArtifact -> {
-        ModuleVersionIdentifier artifactId = resolvedArtifact.getModuleVersion().getId();
+        findResolvedArtifacts(project, allConfigurations).forEach(resolvedArtifact -> {
+          ModuleVersionIdentifier artifactId = resolvedArtifact.getModuleVersion().getId();
 
-        Artifact artifact = new Artifact()
-            .setId(artifactId.getGroup() + ":" + artifactId.getName() + ":" + artifactId.getVersion())
-            .setPathname(resolvedArtifact.getFile())
-            .setMonitored(true);
+          Artifact artifact = new Artifact()
+              .setId(artifactId.getGroup() + ":" + artifactId.getName() + ":" + artifactId.getVersion())
+              .setPathname(resolvedArtifact.getFile())
+              .setMonitored(true);
 
-        module.addConsumedArtifact(artifact);
-      });
+          module.addConsumedArtifact(artifact);
+        });
 
-      findResolvedDependencies(project, allConfigurations).forEach(resolvedDependency ->
-        module.addDependency(processDependency(resolvedDependency, true, new HashSet<>()))
-      );
+        findResolvedDependencies(project, allConfigurations).forEach(resolvedDependency ->
+          module.addDependency(processDependency(resolvedDependency, true, new HashSet<>()))
+        );
 
-      modules.add(module);
+        modules.add(module);
+      }
     });
 
     return modules;

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -88,7 +88,7 @@ public class DependenciesFinder
         .collect(Collectors.toSet());
   }
 
-  public List<Module> findModules(Project rootProject, boolean allConfigurations, List<String> modulesExcluded) {
+  public List<Module> findModules(Project rootProject, boolean allConfigurations, Set<String> modulesExcluded) {
     List<Module> modules = new ArrayList<>();
 
     rootProject.allprojects(project -> {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqPluginExtension.java
@@ -15,6 +15,9 @@
  */
 package org.sonatype.gradle.plugins.scan.nexus.iq;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.sonatype.clm.dto.model.policy.Stage;
 import com.sonatype.insight.brain.client.PolicyAction;
 
@@ -42,11 +45,14 @@ public class NexusIqPluginExtension
 
   private String simulatedPolicyActionId;
 
+  private List<String> modulesExcluded;
+
   public NexusIqPluginExtension(Project project) {
     stage = Stage.ID_BUILD;
     simulationEnabled = false;
     simulatedPolicyActionId = PolicyAction.NONE.toString();
     scanFolderPath = project.getBuildDir() + "/sonatype-clm/";
+    modulesExcluded = Collections.emptyList();
   }
 
   public String getUsername() {
@@ -128,5 +134,13 @@ public class NexusIqPluginExtension
 
   public void setSimulatedPolicyActionId(final String simulatedPolicyActionId) {
     this.simulatedPolicyActionId = simulatedPolicyActionId;
+  }
+
+  public List<String> getModulesExcluded() {
+    return modulesExcluded;
+  }
+
+  public void setModulesExcluded(List<String> modulesExcluded) {
+    this.modulesExcluded = modulesExcluded;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqPluginExtension.java
@@ -16,7 +16,7 @@
 package org.sonatype.gradle.plugins.scan.nexus.iq;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 import com.sonatype.clm.dto.model.policy.Stage;
 import com.sonatype.insight.brain.client.PolicyAction;
@@ -45,14 +45,14 @@ public class NexusIqPluginExtension
 
   private String simulatedPolicyActionId;
 
-  private List<String> modulesExcluded;
+  private Set<String> modulesExcluded;
 
   public NexusIqPluginExtension(Project project) {
     stage = Stage.ID_BUILD;
     simulationEnabled = false;
     simulatedPolicyActionId = PolicyAction.NONE.toString();
     scanFolderPath = project.getBuildDir() + "/sonatype-clm/";
-    modulesExcluded = Collections.emptyList();
+    modulesExcluded = Collections.emptySet();
   }
 
   public String getUsername() {
@@ -136,11 +136,11 @@ public class NexusIqPluginExtension
     this.simulatedPolicyActionId = simulatedPolicyActionId;
   }
 
-  public List<String> getModulesExcluded() {
+  public Set<String> getModulesExcluded() {
     return modulesExcluded;
   }
 
-  public void setModulesExcluded(List<String> modulesExcluded) {
+  public void setModulesExcluded(Set<String> modulesExcluded) {
     this.modulesExcluded = modulesExcluded;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
@@ -80,7 +80,7 @@ public class NexusIqScanTask
               Collections.singletonList(new Action(extension.getSimulatedPolicyActionId()))));
         }
 
-        dependenciesFinder.findModules(getProject(), extension.isAllConfigurations());
+        dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(), extension.getModulesExcluded());
 
         applicationPolicyEvaluation =
             new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 1, alerts, "simulated/report");
@@ -106,7 +106,8 @@ public class NexusIqScanTask
             iqClient.getProprietaryConfigForApplicationEvaluation(extension.getApplicationId());
 
         File scanFolder = new File(extension.getScanFolderPath());
-        List<Module> modules = dependenciesFinder.findModules(getProject(), extension.isAllConfigurations());
+        List<Module> modules = dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(),
+            extension.getModulesExcluded());
 
         ScanResult scanResult = iqClient.scan(extension.getApplicationId(), proprietaryConfig, new Properties(),
             Collections.emptyList(), scanFolder, Collections.emptyMap(), Collections.emptySet(), modules);
@@ -209,6 +210,11 @@ public class NexusIqScanTask
   @Input
   public boolean isAllConfigurations() {
     return extension.isAllConfigurations();
+  }
+
+  @Input
+  public List<String> getModulesExcluded() {
+    return extension.getModulesExcluded();
   }
 
   @VisibleForTesting

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTask.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 import com.sonatype.insight.brain.client.PolicyAction;
 import com.sonatype.insight.scan.module.model.Module;
@@ -213,7 +214,7 @@ public class NexusIqScanTask
   }
 
   @Input
-  public List<String> getModulesExcluded() {
+  public Set<String> getModulesExcluded() {
     return extension.getModulesExcluded();
   }
 

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -15,6 +15,7 @@
  */
 package org.sonatype.gradle.plugins.scan.common;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -246,7 +247,7 @@ public class DependenciesFinderTest
   @Test
   public void testFindModules_singleModule() {
     Project project = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    List<Module> modules = finder.findModules(project, false);
+    List<Module> modules = finder.findModules(project, false, Collections.emptyList());
 
     assertThat(modules).hasSize(1);
 
@@ -267,7 +268,7 @@ public class DependenciesFinderTest
   public void testFindModules_multiModule() {
     Project parentProject = ProjectBuilder.builder().withName("parent").build();
     Project childProject = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false, parentProject);
-    List<Module> modules = finder.findModules(parentProject, false);
+    List<Module> modules = finder.findModules(parentProject, false, Collections.emptyList());
 
     assertThat(modules).hasSize(2);
 
@@ -286,6 +287,16 @@ public class DependenciesFinderTest
 
     Artifact artifact = childModule.getConsumedArtifacts().get(0);
     assertThat(artifact.getId()).isEqualTo(COMMONS_COLLECTIONS_DEPENDENCY);
+  }
+
+  @Test
+  public void testFindModules_multiModuleWithModuleExcluded() {
+    Project parentProject = ProjectBuilder.builder().withName("parent").build();
+    Project childProject = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false, parentProject);
+    List<Module> modules = finder.findModules(parentProject, false, Collections.singletonList(childProject.getName()));
+
+    assertThat(modules).hasSize(1);
+    assertThat(modules.get(0).getId()).isEqualTo(parentProject.getName());
   }
 
   @Test

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -247,7 +247,7 @@ public class DependenciesFinderTest
   @Test
   public void testFindModules_singleModule() {
     Project project = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    List<Module> modules = finder.findModules(project, false, Collections.emptyList());
+    List<Module> modules = finder.findModules(project, false, Collections.emptySet());
 
     assertThat(modules).hasSize(1);
 
@@ -268,7 +268,7 @@ public class DependenciesFinderTest
   public void testFindModules_multiModule() {
     Project parentProject = ProjectBuilder.builder().withName("parent").build();
     Project childProject = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false, parentProject);
-    List<Module> modules = finder.findModules(parentProject, false, Collections.emptyList());
+    List<Module> modules = finder.findModules(parentProject, false, Collections.emptySet());
 
     assertThat(modules).hasSize(2);
 
@@ -293,7 +293,7 @@ public class DependenciesFinderTest
   public void testFindModules_multiModuleWithModuleExcluded() {
     Project parentProject = ProjectBuilder.builder().withName("parent").build();
     Project childProject = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false, parentProject);
-    List<Module> modules = finder.findModules(parentProject, false, Collections.singletonList(childProject.getName()));
+    List<Module> modules = finder.findModules(parentProject, false, Collections.singleton(childProject.getName()));
 
     assertThat(modules).hasSize(1);
     assertThat(modules.get(0).getId()).isEqualTo(parentProject.getName());

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTaskTest.java
@@ -44,7 +44,7 @@ import org.slf4j.Logger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -82,7 +82,7 @@ public class NexusIqScanTaskTest
         new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0, Collections.emptyList(), "simulated/report"));
     when(builderMock.build()).thenReturn(iqClientMock);
 
-    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anyList()))
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
         .thenReturn(Collections.emptyList());
   }
 
@@ -104,7 +104,7 @@ public class NexusIqScanTaskTest
 
     task.scan();
 
-    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anyList());
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet());
     assertThat(userAgentCaptor.getValue())
         .matches("Sonatype_Nexus_Gradle/[^\\s]+ \\(Java [^;]+; [^;]+ [^;]+; Gradle [^;]+\\)");
     verify(iqClientMock).validateServerVersion(anyString());

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/NexusIqScanTaskTest.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -81,7 +82,8 @@ public class NexusIqScanTaskTest
         new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0, Collections.emptyList(), "simulated/report"));
     when(builderMock.build()).thenReturn(iqClientMock);
 
-    when(dependenciesFinderMock.findModules(any(Project.class), eq(false))).thenReturn(Collections.emptyList());
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anyList()))
+        .thenReturn(Collections.emptyList());
   }
 
   @Test
@@ -102,7 +104,7 @@ public class NexusIqScanTaskTest
 
     task.scan();
 
-    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false));
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anyList());
     assertThat(userAgentCaptor.getValue())
         .matches("Sonatype_Nexus_Gradle/[^\\s]+ \\(Java [^;]+; [^;]+ [^;]+; Gradle [^;]+\\)");
     verify(iqClientMock).validateServerVersion(anyString());


### PR DESCRIPTION
When having a multi-module project, like this:

```
sample-project
 --> sub-module-1
 --> sub-module-2
 --> sub-module-3
```

A new property will allow to exclude some of those from scan and evaluation in Nexus IQ:

`modulesExcluded = ['sub-module-1', 'sub-module-2']`

It relates to the following issue #s:
* Fixes #81

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
