### PR TITLE
CLM-19069 New index task to save a module descriptor for Nexus IQ.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Gradle can be used to build projects developed in various programming languages.
 - Edit its `build.gradle` file adding this:
 ```
 plugins {
-  id 'org.sonatype.gradle.plugins.scan' version '2.0.10' // Update the version as needed
+  id 'org.sonatype.gradle.plugins.scan' version '2.1.1' // Update the version as needed
 }
 ```
 
@@ -96,7 +96,7 @@ ossIndexAudit {
 - Open Terminal on the project's root and run `./gradlew ossIndexAudit`
 - You should see the audit result on Terminal.
 
-### Nexus IQ Server
+### Nexus IQ Server Scan and Evaluate
 - Start a local instance of IQ Server, or get the URL and credentials of a remote one.
 - Configure IQ Server settings inside the `nexusIQScan` configuration on the file `build.gradle` e.g.
 ```
@@ -115,6 +115,14 @@ nexusIQScan {
 ```
 - Open Terminal on the project's root and run `./gradlew nexusIQScan`
 - You should see the scan report URL report on Terminal.
+
+### Nexus IQ Index
+Allow to save information about the dependencies of a project into a module information file (module.xml) that Sonatype CI tools can use to include these dependencies in a scan.
+```
+nexusIQIndex {
+     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from indexing.
+}
+```
 
 ### Sensitive Data
 Sometimes it's not desirable to keep sensitive data stored on `build.gradle`. For such cases it's possible to use project

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ nexusIQScan {
 - You should see the scan report URL report on Terminal.
 
 ### Nexus IQ Index
-Allow to save information about the dependencies of a project into a module information file (module.xml) that Sonatype CI tools can use to include these dependencies in a scan.
+Allows you to save information about the dependencies of a project into module information (module.xml) files that Sonatype CI tools can use to include these dependencies in a scan.
 ```
 nexusIQIndex {
      modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from indexing.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Gradle can be used to build projects developed in various programming languages.
 - Edit its `build.gradle` file adding this:
 ```
 plugins {
-  id 'org.sonatype.gradle.plugins.scan' version '2.1.1' // Update the version as needed
+  id 'org.sonatype.gradle.plugins.scan' version '2.2.0' // Update the version as needed
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 group=org.sonatype.gradle.plugins
-version=2.1.1-SNAPSHOT
+version=2.2.0-SNAPSHOT
 release.useAutomaticVersion=true
 
 nexusPlatformApiVersion=3.37

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.sonatype.gradle.plugins.scan.nexus.iq.scan.NexusIqPluginScanExtension.SONATYPE_CLM_FOLDER;
 
 @RunWith(Parameterized.class)
 public abstract class ScanPluginIntegrationTestBase
@@ -180,7 +181,7 @@ public abstract class ScanPluginIntegrationTestBase
 
     String resultOutput = result.getOutput();
     assertThat(resultOutput).contains("Saved module information to");
-    assertThat(resultOutput).contains("sonatype-clm" + File.separator + "module.xml");
+    assertThat(resultOutput).contains(SONATYPE_CLM_FOLDER + File.separator + "module.xml");
     assertThat(result.task(":nexusIQIndex").getOutcome()).isEqualTo(SUCCESS);
   }
   

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.sonatype.gradle.plugins.scan.nexus.iq.index.NexusIqIndexTask.MODULE_XML_FILE;
 import static org.sonatype.gradle.plugins.scan.nexus.iq.scan.NexusIqPluginScanExtension.SONATYPE_CLM_FOLDER;
 
 @RunWith(Parameterized.class)
@@ -181,7 +182,7 @@ public abstract class ScanPluginIntegrationTestBase
 
     String resultOutput = result.getOutput();
     assertThat(resultOutput).contains("Saved module information to");
-    assertThat(resultOutput).contains(SONATYPE_CLM_FOLDER + File.separator + "module.xml");
+    assertThat(resultOutput).contains(SONATYPE_CLM_FOLDER + File.separator + MODULE_XML_FILE);
     assertThat(result.task(":nexusIQIndex").getOutcome()).isEqualTo(SUCCESS);
   }
   

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
@@ -168,6 +168,23 @@ public abstract class ScanPluginIntegrationTestBase
   }
 
   @Test
+  public void testIndexTask_NexusIQ() throws IOException {
+    writeFile(buildFile, "control_default.gradle");
+
+    final BuildResult result = GradleRunner.create()
+        .withGradleVersion(gradleVersion)
+        .withProjectDir(testProjectDir.getRoot())
+        .withPluginClasspath()
+        .withArguments("nexusIQIndex", "--info")
+        .build();
+
+    String resultOutput = result.getOutput();
+    assertThat(resultOutput).contains("Saved module information to");
+    assertThat(resultOutput).contains("sonatype-clm" + File.separator + "module.xml");
+    assertThat(result.task(":nexusIQIndex").getOutcome()).isEqualTo(SUCCESS);
+  }
+  
+  @Test
   public void testAuditTask_NoVulnerabilities_OssIndex_Default_Empty() throws IOException {
     writeFile(buildFile, "control_default_not_all.gradle");
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ScanPlugin.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ScanPlugin.java
@@ -15,8 +15,10 @@
  */
 package org.sonatype.gradle.plugins.scan;
 
-import org.sonatype.gradle.plugins.scan.nexus.iq.NexusIqPluginExtension;
-import org.sonatype.gradle.plugins.scan.nexus.iq.NexusIqScanTask;
+import org.sonatype.gradle.plugins.scan.nexus.iq.index.NexusIqIndexTask;
+import org.sonatype.gradle.plugins.scan.nexus.iq.index.NexusIqPluginIndexExtension;
+import org.sonatype.gradle.plugins.scan.nexus.iq.scan.NexusIqPluginScanExtension;
+import org.sonatype.gradle.plugins.scan.nexus.iq.scan.NexusIqScanTask;
 import org.sonatype.gradle.plugins.scan.ossindex.OssIndexAuditTask;
 import org.sonatype.gradle.plugins.scan.ossindex.OssIndexPluginExtension;
 
@@ -29,10 +31,16 @@ public class ScanPlugin implements Plugin<Project>
 
   @Override
   public void apply(Project project) {
-    project.getExtensions().create("nexusIQScan", NexusIqPluginExtension.class, project);
+    project.getExtensions().create("nexusIQScan", NexusIqPluginScanExtension.class, project);
     NexusIqScanTask nexusIqScanTask = project.getTasks().create("nexusIQScan", NexusIqScanTask.class);
     nexusIqScanTask.setGroup(SONATYPE_GROUP);
     nexusIqScanTask.setDescription("Scan and evaluate the dependencies of the project using Nexus IQ Server.");
+
+    project.getExtensions().create("nexusIQIndex", NexusIqPluginIndexExtension.class, project);
+    NexusIqIndexTask nexusIqIndexTask = project.getTasks().create("nexusIQIndex", NexusIqIndexTask.class);
+    nexusIqIndexTask.setGroup(SONATYPE_GROUP);
+    nexusIqIndexTask.setDescription("Saves information about the dependencies of a project into a module information "
+        + "file that Sonatype CI tools can use to include these dependencies in a scan.");
 
     project.getExtensions().create("ossIndexAudit", OssIndexPluginExtension.class, project);
     OssIndexAuditTask ossIndexAuditTask = project.getTasks().create("ossIndexAudit", OssIndexAuditTask.class);

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ScanPlugin.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ScanPlugin.java
@@ -39,8 +39,8 @@ public class ScanPlugin implements Plugin<Project>
     project.getExtensions().create("nexusIQIndex", NexusIqPluginIndexExtension.class, project);
     NexusIqIndexTask nexusIqIndexTask = project.getTasks().create("nexusIQIndex", NexusIqIndexTask.class);
     nexusIqIndexTask.setGroup(SONATYPE_GROUP);
-    nexusIqIndexTask.setDescription("Saves information about the dependencies of a project into a module information "
-        + "file that Sonatype CI tools can use to include these dependencies in a scan.");
+    nexusIqIndexTask.setDescription("Saves information about the dependencies of a project into module information "
+        + "(module.xml) files that Sonatype CI tools can use to include these dependencies in a scan.");
 
     project.getExtensions().create("ossIndexAudit", OssIndexPluginExtension.class, project);
     OssIndexAuditTask ossIndexAuditTask = project.getTasks().create("ossIndexAudit", OssIndexAuditTask.class);

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
@@ -35,6 +35,8 @@ import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesti
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.sonatype.gradle.plugins.scan.nexus.iq.scan.NexusIqPluginScanExtension.SONATYPE_CLM_FOLDER;
+
 public class NexusIqIndexTask
     extends DefaultTask
 {
@@ -60,7 +62,7 @@ public class NexusIqIndexTask
       List<File> files = new ArrayList<>(modules.size());
 
       for (Module module : modules) {
-        File file = Paths.get(module.getPathname(), "build", "sonatype-clm", "module.xml").toFile();
+        File file = Paths.get(module.getPathname(), "build", SONATYPE_CLM_FOLDER, "module.xml").toFile();
         moduleIoManager.writeModule(file, module);
         files.add(file);
       }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
@@ -40,6 +40,8 @@ import static org.sonatype.gradle.plugins.scan.nexus.iq.scan.NexusIqPluginScanEx
 public class NexusIqIndexTask
     extends DefaultTask
 {
+  public static final String MODULE_XML_FILE = "module.xml";
+
   private final Logger log = LoggerFactory.getLogger(NexusIqIndexTask.class);
 
   private final NexusIqPluginIndexExtension extension;
@@ -62,7 +64,7 @@ public class NexusIqIndexTask
       List<File> files = new ArrayList<>(modules.size());
 
       for (Module module : modules) {
-        File file = Paths.get(module.getPathname(), "build", SONATYPE_CLM_FOLDER, "module.xml").toFile();
+        File file = Paths.get(module.getPathname(), "build", SONATYPE_CLM_FOLDER, MODULE_XML_FILE).toFile();
         moduleIoManager.writeModule(file, module);
         files.add(file);
       }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
@@ -72,7 +72,7 @@ public class NexusIqIndexTask
       log.info("Saved module information to {}", StringUtils.join(files, ", "));
     }
     catch (Exception e) {
-      throw new GradleException("Could not save the module descriptor for the project: " + e.getMessage(), e);
+      throw new GradleException("Could not save the module information for the project: " + e.getMessage(), e);
     }
   }
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.nexus.iq.index;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.sonatype.insight.scan.module.model.Module;
+import com.sonatype.insight.scan.module.model.io.ModuleIoManager;
+
+import org.sonatype.gradle.plugins.scan.common.DependenciesFinder;
+
+import com.google.common.io.Files;
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NexusIqIndexTask
+    extends DefaultTask
+{
+  private final Logger log = LoggerFactory.getLogger(NexusIqIndexTask.class);
+
+  private final NexusIqPluginIndexExtension extension;
+
+  private DependenciesFinder dependenciesFinder;
+
+  private ModuleIoManager moduleIoManager;
+
+  public NexusIqIndexTask() {
+    extension = getProject().getExtensions().getByType(NexusIqPluginIndexExtension.class);
+    dependenciesFinder = new DependenciesFinder();
+    moduleIoManager = new ModuleIoManager(log);
+  }
+
+  @TaskAction
+  public void saveModule() {
+    try {
+      List<Module> modules =
+          dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(), extension.getModulesExcluded());
+      File file = new File(extension.getModuleFile());
+      List<File> files = new ArrayList<>(modules.size());
+
+      if (modules.size() == 1) {
+        moduleIoManager.writeModule(file, modules.get(0));
+        files.add(file);
+      }
+      else {
+        File parent = new File(extension.getModuleFile()).getParentFile();
+        String filename = Files.getNameWithoutExtension(file.getName());
+        for (Module module : modules) {
+          File moduleFile = new File(parent, filename + "-" + module.getId().replace(':', '-') + ".xml");
+          moduleIoManager.writeModule(moduleFile, module);
+          files.add(moduleFile);
+        }
+      }
+
+      log.info("Saved module information to {}", StringUtils.join(files, ", "));
+    }
+    catch (Exception e) {
+      throw new GradleException("Could not save the module descriptor for the project: " + e.getMessage(), e);
+    }
+  }
+
+  @VisibleForTesting
+  void setDependenciesFinder(DependenciesFinder dependenciesFinder) {
+    this.dependenciesFinder = dependenciesFinder;
+  }
+
+  @VisibleForTesting
+  void setModuleIoManager(ModuleIoManager moduleIoManager) {
+    this.moduleIoManager = moduleIoManager;
+  }
+
+  @Input
+  public boolean isAllConfigurations() {
+    return extension.isAllConfigurations();
+  }
+
+  @Input
+  public Set<String> getModulesExcluded() {
+    return extension.getModulesExcluded();
+  }
+
+  @Input
+  public String getModuleFile() {
+    return extension.getModuleFile();
+  }
+}

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
@@ -16,6 +16,7 @@
 package org.sonatype.gradle.plugins.scan.nexus.iq.index;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -25,7 +26,6 @@ import com.sonatype.insight.scan.module.model.io.ModuleIoManager;
 
 import org.sonatype.gradle.plugins.scan.common.DependenciesFinder;
 
-import com.google.common.io.Files;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -57,21 +57,12 @@ public class NexusIqIndexTask
     try {
       List<Module> modules =
           dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(), extension.getModulesExcluded());
-      File file = new File(extension.getModuleFile());
       List<File> files = new ArrayList<>(modules.size());
 
-      if (modules.size() == 1) {
-        moduleIoManager.writeModule(file, modules.get(0));
+      for (Module module : modules) {
+        File file = Paths.get(module.getPathname(), "build", "sonatype-clm", "module.xml").toFile();
+        moduleIoManager.writeModule(file, module);
         files.add(file);
-      }
-      else {
-        File parent = new File(extension.getModuleFile()).getParentFile();
-        String filename = Files.getNameWithoutExtension(file.getName());
-        for (Module module : modules) {
-          File moduleFile = new File(parent, filename + "-" + module.getId().replace(':', '-') + ".xml");
-          moduleIoManager.writeModule(moduleFile, module);
-          files.add(moduleFile);
-        }
       }
 
       log.info("Saved module information to {}", StringUtils.join(files, ", "));
@@ -99,10 +90,5 @@ public class NexusIqIndexTask
   @Input
   public Set<String> getModulesExcluded() {
     return extension.getModulesExcluded();
-  }
-
-  @Input
-  public String getModuleFile() {
-    return extension.getModuleFile();
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqPluginIndexExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqPluginIndexExtension.java
@@ -15,7 +15,6 @@
  */
 package org.sonatype.gradle.plugins.scan.nexus.iq.index;
 
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Set;
 
@@ -27,11 +26,8 @@ public class NexusIqPluginIndexExtension
 
   private Set<String> modulesExcluded;
 
-  private String moduleFile;
-
   public NexusIqPluginIndexExtension(Project project) {
     modulesExcluded = Collections.emptySet();
-    moduleFile = Paths.get(project.getBuildDir().getAbsolutePath(), "sonatype-clm", "module.xml").toString();
   }
 
   public boolean isAllConfigurations() {
@@ -48,13 +44,5 @@ public class NexusIqPluginIndexExtension
 
   public void setModulesExcluded(Set<String> modulesExcluded) {
     this.modulesExcluded = modulesExcluded;
-  }
-
-  public String getModuleFile() {
-    return moduleFile;
-  }
-
-  public void setModuleFile(String moduleFile) {
-    this.moduleFile = moduleFile;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqPluginIndexExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqPluginIndexExtension.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.nexus.iq.index;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Set;
+
+import org.gradle.api.Project;
+
+public class NexusIqPluginIndexExtension
+{
+  private boolean allConfigurations;
+
+  private Set<String> modulesExcluded;
+
+  private String moduleFile;
+
+  public NexusIqPluginIndexExtension(Project project) {
+    modulesExcluded = Collections.emptySet();
+    moduleFile = Paths.get(project.getBuildDir().getAbsolutePath(), "sonatype-clm", "module.xml").toString();
+  }
+
+  public boolean isAllConfigurations() {
+    return allConfigurations;
+  }
+
+  public void setAllConfigurations(boolean allConfigurations) {
+    this.allConfigurations = allConfigurations;
+  }
+
+  public Set<String> getModulesExcluded() {
+    return modulesExcluded;
+  }
+
+  public void setModulesExcluded(Set<String> modulesExcluded) {
+    this.modulesExcluded = modulesExcluded;
+  }
+
+  public String getModuleFile() {
+    return moduleFile;
+  }
+
+  public void setModuleFile(String moduleFile) {
+    this.moduleFile = moduleFile;
+  }
+}

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.sonatype.gradle.plugins.scan.nexus.iq;
+package org.sonatype.gradle.plugins.scan.nexus.iq.scan;
 
 import java.util.Collections;
 import java.util.Set;
@@ -23,7 +23,7 @@ import com.sonatype.insight.brain.client.PolicyAction;
 
 import org.gradle.api.Project;
 
-public class NexusIqPluginExtension
+public class NexusIqPluginScanExtension
 {
   private String stage;
 
@@ -51,7 +51,7 @@ public class NexusIqPluginExtension
 
   private String dirExcludes;
 
-  public NexusIqPluginExtension(Project project) {
+  public NexusIqPluginScanExtension(Project project) {
     stage = Stage.ID_BUILD;
     simulationEnabled = false;
     simulatedPolicyActionId = PolicyAction.NONE.toString();

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
@@ -15,6 +15,7 @@
  */
 package org.sonatype.gradle.plugins.scan.nexus.iq.scan;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.Set;
 
@@ -25,6 +26,8 @@ import org.gradle.api.Project;
 
 public class NexusIqPluginScanExtension
 {
+  public static final String SONATYPE_CLM_FOLDER = "sonatype-clm";
+
   private String stage;
 
   private String scanFolderPath;
@@ -55,7 +58,7 @@ public class NexusIqPluginScanExtension
     stage = Stage.ID_BUILD;
     simulationEnabled = false;
     simulatedPolicyActionId = PolicyAction.NONE.toString();
-    scanFolderPath = project.getBuildDir() + "/sonatype-clm/";
+    scanFolderPath = project.getBuildDir() + File.separator + SONATYPE_CLM_FOLDER + File.separator;
     modulesExcluded = Collections.emptySet();
     dirIncludes = "";
     dirExcludes = "";

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.sonatype.gradle.plugins.scan.nexus.iq;
+package org.sonatype.gradle.plugins.scan.nexus.iq.scan;
 
 import java.io.File;
 import java.net.URI;
@@ -58,12 +58,12 @@ public class NexusIqScanTask
 
   private static final String USER_AGENT_NAME = "Sonatype_Nexus_Gradle";
 
-  private final NexusIqPluginExtension extension;
+  private final NexusIqPluginScanExtension extension;
 
   private DependenciesFinder dependenciesFinder;
 
   public NexusIqScanTask() {
-    extension = getProject().getExtensions().getByType(NexusIqPluginExtension.class);
+    extension = getProject().getExtensions().getByType(NexusIqPluginScanExtension.class);
     dependenciesFinder = new DependenciesFinder();
   }
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -21,9 +21,11 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.sonatype.goodies.packageurl.PackageUrl;
 import org.sonatype.goodies.packageurl.PackageUrlBuilder;
@@ -70,8 +72,10 @@ public class OssIndexAuditTask
     boolean hasVulnerabilities;
 
     try (OssindexClient ossIndexClient = buildOssIndexClient()) {
-      Set<ResolvedDependency> dependencies =
-          dependenciesFinder.findResolvedDependencies(getProject(), extension.isAllConfigurations());
+      Set<ResolvedDependency> dependencies = getProject().getAllprojects().stream()
+          .flatMap(
+              project -> dependenciesFinder.findResolvedDependencies(project, extension.isAllConfigurations()).stream())
+          .collect(Collectors.toCollection(LinkedHashSet::new));
       BiMap<ResolvedDependency, PackageUrl> dependenciesMap = HashBiMap.create();
 
       dependencies.forEach(dependency -> buildDependenciesMap(dependency, dependenciesMap));

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ScanPluginTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ScanPluginTest.java
@@ -15,8 +15,10 @@
  */
 package org.sonatype.gradle.plugins.scan;
 
-import org.sonatype.gradle.plugins.scan.nexus.iq.NexusIqPluginExtension;
-import org.sonatype.gradle.plugins.scan.nexus.iq.NexusIqScanTask;
+import org.sonatype.gradle.plugins.scan.nexus.iq.index.NexusIqPluginIndexExtension;
+import org.sonatype.gradle.plugins.scan.nexus.iq.index.NexusIqIndexTask;
+import org.sonatype.gradle.plugins.scan.nexus.iq.scan.NexusIqPluginScanExtension;
+import org.sonatype.gradle.plugins.scan.nexus.iq.scan.NexusIqScanTask;
 import org.sonatype.gradle.plugins.scan.ossindex.OssIndexAuditTask;
 import org.sonatype.gradle.plugins.scan.ossindex.OssIndexPluginExtension;
 
@@ -42,7 +44,10 @@ public class ScanPluginTest
     plugin.apply(project);
 
     assertThat(project.getTasks().getByName("nexusIQScan")).isInstanceOf(NexusIqScanTask.class);
-    assertThat(project.getExtensions().getByName("nexusIQScan")).isInstanceOf(NexusIqPluginExtension.class);
+    assertThat(project.getExtensions().getByName("nexusIQScan")).isInstanceOf(NexusIqPluginScanExtension.class);
+
+    assertThat(project.getTasks().getByName("nexusIQIndex")).isInstanceOf(NexusIqIndexTask.class);
+    assertThat(project.getExtensions().getByName("nexusIQIndex")).isInstanceOf(NexusIqPluginIndexExtension.class);
 
     assertThat(project.getTasks().getByName("ossIndexAudit")).isInstanceOf(OssIndexAuditTask.class);
     assertThat(project.getExtensions().getByName("ossIndexAudit")).isInstanceOf(OssIndexPluginExtension.class);

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -156,6 +156,15 @@ public class DependenciesFinderTest
   }
 
   @Test
+  public void testFindResolvedDependencies_multiModuleProject() {
+    Project parentProject = ProjectBuilder.builder().withName("parent").build();
+    Project childProject = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false, parentProject);
+
+    assertThat(finder.findResolvedDependencies(childProject, false)).hasSize(1);
+    assertThat(finder.findResolvedDependencies(parentProject, false)).isEmpty();
+  }
+
+  @Test
   public void testFindResolvedDependencies_copyConfigurationAfterResolveException() {
     Project project = spy(buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false));
     ConfigurationContainer configurationContainer = spy(project.getConfigurations());
@@ -219,6 +228,8 @@ public class DependenciesFinderTest
 
     assertThat(module).isNotNull();
     assertThat(module.getIdKind()).isEqualTo("gradle");
+    assertThat(module.getBuilderInfo(Module.BI_CLM_TOOL)).isEqualTo("gradle");
+    assertThat(module.getBuilderInfo(Module.BI_CLM_VERSION)).isEqualTo(PluginVersionUtils.getPluginVersion());
     assertThat(module.getPathname()).isEqualTo(project.getProjectDir().getAbsolutePath());
     assertThat(module.getId()).isEqualTo(project.getName());
   }

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
@@ -17,6 +17,7 @@ package org.sonatype.gradle.plugins.scan.nexus.iq.index;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -38,6 +39,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sonatype.gradle.plugins.scan.nexus.iq.scan.NexusIqPluginScanExtension.SONATYPE_CLM_FOLDER;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NexusIqIndexTaskTest
@@ -53,7 +55,7 @@ public class NexusIqIndexTaskTest
     Module module = new Module()
         .setId("test-module")
         .setPathname("test-module");
-    File file = new File("test-module/build/sonatype-clm/module.xml");
+    File file = Paths.get("test-module", "build", SONATYPE_CLM_FOLDER, "module.xml").toFile();
 
     when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
         .thenReturn(Collections.singletonList(module));
@@ -76,8 +78,8 @@ public class NexusIqIndexTaskTest
     Module module2 = new Module()
         .setId("test-module-2")
         .setPathname("test-module-2");
-    File file1 = new File("test-module-1/build/sonatype-clm/module.xml");
-    File file2 = new File("test-module-2/build/sonatype-clm/module.xml");
+    File file1 = Paths.get("test-module-1", "build", SONATYPE_CLM_FOLDER, "module.xml").toFile();
+    File file2 = Paths.get("test-module-2", "build", SONATYPE_CLM_FOLDER, "module.xml").toFile();
 
     when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
         .thenReturn(Arrays.asList(module1, module2));

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
@@ -39,6 +39,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sonatype.gradle.plugins.scan.nexus.iq.index.NexusIqIndexTask.MODULE_XML_FILE;
 import static org.sonatype.gradle.plugins.scan.nexus.iq.scan.NexusIqPluginScanExtension.SONATYPE_CLM_FOLDER;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -55,7 +56,7 @@ public class NexusIqIndexTaskTest
     Module module = new Module()
         .setId("test-module")
         .setPathname("test-module");
-    File file = Paths.get("test-module", "build", SONATYPE_CLM_FOLDER, "module.xml").toFile();
+    File file = Paths.get("test-module", "build", SONATYPE_CLM_FOLDER, MODULE_XML_FILE).toFile();
 
     when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
         .thenReturn(Collections.singletonList(module));
@@ -78,8 +79,8 @@ public class NexusIqIndexTaskTest
     Module module2 = new Module()
         .setId("test-module-2")
         .setPathname("test-module-2");
-    File file1 = Paths.get("test-module-1", "build", SONATYPE_CLM_FOLDER, "module.xml").toFile();
-    File file2 = Paths.get("test-module-2", "build", SONATYPE_CLM_FOLDER, "module.xml").toFile();
+    File file1 = Paths.get("test-module-1", "build", SONATYPE_CLM_FOLDER, MODULE_XML_FILE).toFile();
+    File file2 = Paths.get("test-module-2", "build", SONATYPE_CLM_FOLDER, MODULE_XML_FILE).toFile();
 
     when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
         .thenReturn(Arrays.asList(module1, module2));

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
@@ -108,7 +108,6 @@ public class NexusIqIndexTaskTest
 
     NexusIqIndexTask task = buildIndexTask(modulesExcluded);
     task.setDependenciesFinder(dependenciesFinderMock);
-    // task.setModuleIoManager(moduleIoManagerMock);
     task.saveModule();
 
     verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), eq(modulesExcluded));

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
@@ -50,14 +50,16 @@ public class NexusIqIndexTaskTest
 
   @Test
   public void testSaveModule_singleModule() throws IOException {
-    Module module = new Module().setId("test-module");
-    File file = new File("test-file.xml");
+    Module module = new Module()
+        .setId("test-module")
+        .setPathname("test-module");
+    File file = new File("test-module/build/sonatype-clm/module.xml");
 
     when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
         .thenReturn(Collections.singletonList(module));
     doNothing().when(moduleIoManagerMock).writeModule(file, module);
 
-    NexusIqIndexTask task = buildIndexTask(file.getPath());
+    NexusIqIndexTask task = buildIndexTask();
     task.setDependenciesFinder(dependenciesFinderMock);
     task.setModuleIoManager(moduleIoManagerMock);
     task.saveModule();
@@ -68,17 +70,21 @@ public class NexusIqIndexTaskTest
 
   @Test
   public void testSaveModule_multipleModules() throws IOException {
-    Module module1 = new Module().setId("test-module:1");
-    Module module2 = new Module().setId("test-module:2");
-    File file1 = new File("test-file-test-module-1.xml");
-    File file2 = new File("test-file-test-module-2.xml");
+    Module module1 = new Module()
+        .setId("test-module-1")
+        .setPathname("test-module-1");
+    Module module2 = new Module()
+        .setId("test-module-2")
+        .setPathname("test-module-2");
+    File file1 = new File("test-module-1/build/sonatype-clm/module.xml");
+    File file2 = new File("test-module-2/build/sonatype-clm/module.xml");
 
     when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
         .thenReturn(Arrays.asList(module1, module2));
     doNothing().when(moduleIoManagerMock).writeModule(file1, module1);
     doNothing().when(moduleIoManagerMock).writeModule(file2, module2);
 
-    NexusIqIndexTask task = buildIndexTask("test-file.xml");
+    NexusIqIndexTask task = buildIndexTask();
     task.setDependenciesFinder(dependenciesFinderMock);
     task.setModuleIoManager(moduleIoManagerMock);
     task.saveModule();
@@ -88,12 +94,9 @@ public class NexusIqIndexTaskTest
     verify(moduleIoManagerMock).writeModule(file2, module2);
   }
 
-  private NexusIqIndexTask buildIndexTask(String moduleFile) {
+  private NexusIqIndexTask buildIndexTask() {
     Project project = ProjectBuilder.builder().build();
-
     NexusIqPluginIndexExtension extension = new NexusIqPluginIndexExtension(project);
-    extension.setModuleFile(moduleFile);
-
     project.getExtensions().add("nexusIQIndex", extension);
     return project.getTasks().create("nexusIQIndex", NexusIqIndexTask.class);
   }

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.nexus.iq.index;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import com.sonatype.insight.scan.module.model.Module;
+import com.sonatype.insight.scan.module.model.io.ModuleIoManager;
+
+import org.sonatype.gradle.plugins.scan.common.DependenciesFinder;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NexusIqIndexTaskTest
+{
+  @Mock
+  private DependenciesFinder dependenciesFinderMock;
+
+  @Mock
+  private ModuleIoManager moduleIoManagerMock;
+
+  @Test
+  public void testSaveModule_singleModule() throws IOException {
+    Module module = new Module().setId("test-module");
+    File file = new File("test-file.xml");
+
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
+        .thenReturn(Collections.singletonList(module));
+    doNothing().when(moduleIoManagerMock).writeModule(file, module);
+
+    NexusIqIndexTask task = buildIndexTask(file.getPath());
+    task.setDependenciesFinder(dependenciesFinderMock);
+    task.setModuleIoManager(moduleIoManagerMock);
+    task.saveModule();
+
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet());
+    verify(moduleIoManagerMock).writeModule(file, module);
+  }
+
+  @Test
+  public void testSaveModule_multipleModules() throws IOException {
+    Module module1 = new Module().setId("test-module:1");
+    Module module2 = new Module().setId("test-module:2");
+    File file1 = new File("test-file-test-module-1.xml");
+    File file2 = new File("test-file-test-module-2.xml");
+
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
+        .thenReturn(Arrays.asList(module1, module2));
+    doNothing().when(moduleIoManagerMock).writeModule(file1, module1);
+    doNothing().when(moduleIoManagerMock).writeModule(file2, module2);
+
+    NexusIqIndexTask task = buildIndexTask("test-file.xml");
+    task.setDependenciesFinder(dependenciesFinderMock);
+    task.setModuleIoManager(moduleIoManagerMock);
+    task.saveModule();
+
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet());
+    verify(moduleIoManagerMock).writeModule(file1, module1);
+    verify(moduleIoManagerMock).writeModule(file2, module2);
+  }
+
+  private NexusIqIndexTask buildIndexTask(String moduleFile) {
+    Project project = ProjectBuilder.builder().build();
+
+    NexusIqPluginIndexExtension extension = new NexusIqPluginIndexExtension(project);
+    extension.setModuleFile(moduleFile);
+
+    project.getExtensions().add("nexusIQIndex", extension);
+    return project.getTasks().create("nexusIQIndex", NexusIqIndexTask.class);
+  }
+}

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTaskTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.sonatype.gradle.plugins.scan.nexus.iq;
+package org.sonatype.gradle.plugins.scan.nexus.iq.scan;
 
 import java.io.File;
 import java.util.Collections;
@@ -190,7 +190,7 @@ public class NexusIqScanTaskTest
   {
     Project project = ProjectBuilder.builder().build();
 
-    NexusIqPluginExtension extension = new NexusIqPluginExtension(project);
+    NexusIqPluginScanExtension extension = new NexusIqPluginScanExtension(project);
     extension.setApplicationId("test");
     extension.setServerUrl("http://test");
     extension.setUsername("user");


### PR DESCRIPTION
Brings the "index" feature from the Maven plugin so a XML can be generated and later used by Sonatype CI tools: https://help.sonatype.com/integrations/sonatype-clm-for-maven#SonatypeCLMforMaven-CreatingaComponentIndex

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
