### PR TITLE
docs: Missing slashes before comments in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ ossIndexAudit {
     printBanner = true // if true will print ASCII text banner. By default is true.
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
-    excludeVulnerabilityIds = ['39d74cc8-457a-4e57-89ef-a258420138c5'] list containing ids of vulnerabilities to be ignored
-    excludeCoordinates = ['commons-fileupload:commons-fileupload:1.3'] list containing coordinate of components which if vulnerable should be ignored
+    excludeVulnerabilityIds = ['39d74cc8-457a-4e57-89ef-a258420138c5'] // list containing ids of vulnerabilities to be ignored
+    excludeCoordinates = ['commons-fileupload:commons-fileupload:1.3'] // list containing coordinate of components which if vulnerable should be ignored
 }
 ```
 - Open Terminal on the project's root and run `./gradlew ossIndexAudit`


### PR DESCRIPTION
Hello there! :wave: 

When I first tried to use this tool I found out about 2 missing slashes which made my first execution fail (because I did not pay enough attention). So I figured out I'll open a PR to add them.

This pull request makes the following changes:
* add the missing slashes in the configuration example in `README.md`

I did not take the time to open an issue first as this is a very minor change, hope this is not a problem!

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
