### PR TITLE
#82 Creates an application with a given organization ID if not exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ nexusIQScan {
     password = 'pass'
     serverUrl = 'http://localhost:8070'
     applicationId = 'app'
+    organizationId = 'orgId' // Optional. If provided, a validation will be done to check if the given application ID exists under the organization ID (please note this is different than the organization name). If the application doesn't exists, then it will be created under the organization.
     stage = 'build' // build is used if omitted
     allConfigurations = false // if true includes the dependencies in all resolvable configurations. By default is false, meaning only 'compileClasspath', 'runtimeClasspath', 'releaseCompileClasspath' and 'releaseRuntimeClasspath' are considered
     resultFilePath = 'results.json' // Optional. JSON file containing results of the evaluation

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,9 @@ dependencies {
 
   implementation files ("nexus-platform-api/build/libs/nexus-platform-api-${version}.jar")
   implementation "org.sonatype.ossindex:ossindex-service-client:$ossIndexClientVersion"
+  implementation "io.github.openfeign:feign-core:$feignVersion"
+  implementation "io.github.openfeign:feign-gson:$feignVersion"
+  implementation "com.google.code.gson:gson:$gsonVersion"
 
   testImplementation gradleTestKit()
   testImplementation "junit:junit:$junitVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,8 @@ release.useAutomaticVersion=true
 
 nexusPlatformApiVersion=3.37
 ossIndexClientVersion=1.7.0
+feignVersion=11.7
+gsonVersion=2.8.9
 
 junitVersion=4.13.2
 powermockVersion=2.0.9

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/api/Application.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/api/Application.java
@@ -1,0 +1,65 @@
+/*private java.lang.String name;
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.nexus.iq.api;
+
+public class Application
+{
+  private String id;
+
+  private String publicId;
+
+  private String name;
+
+  private String organizationId;
+
+  public Application(String publicId, String name, String organizationId) {
+    this.publicId = publicId;
+    this.name = name;
+    this.organizationId = organizationId;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getPublicId() {
+    return publicId;
+  }
+
+  public void setPublicId(String publicId) {
+    this.publicId = publicId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+  public void setOrganizationId(String organizationId) {
+    this.organizationId = organizationId;
+  }
+}

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/api/ApplicationList.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/api/ApplicationList.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.nexus.iq.api;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ApplicationList
+{
+  private List<Application> applications = Collections.emptyList();
+
+  public List<Application> getApplications() {
+    return applications;
+  }
+
+  public void setApplications(List<Application> applications) {
+    this.applications = applications;
+  }
+}

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/api/NexusIqApi.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/api/NexusIqApi.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.nexus.iq.api;
+
+import feign.Feign;
+import feign.Headers;
+import feign.Param;
+import feign.RequestInterceptor;
+import feign.RequestLine;
+import feign.RequestTemplate;
+import feign.auth.BasicAuthRequestInterceptor;
+import feign.gson.GsonDecoder;
+import feign.gson.GsonEncoder;
+
+public interface NexusIqApi
+{
+  @RequestLine("GET /api/v2/applications/organization/{organizationId}")
+  ApplicationList getApplicationsByOrganizationId(@Param("organizationId") String organizationId);
+
+  @RequestLine("POST /api/v2/applications")
+  @Headers("Content-Type: application/json")
+  void createApplication(Application application);
+
+  public static NexusIqApi build(String serverUrl, String username, String password, String userAgent) {
+    return Feign.builder()
+        .decoder(new GsonDecoder())
+        .encoder(new GsonEncoder())
+        .requestInterceptor(new BasicAuthRequestInterceptor(username, password))
+        .requestInterceptor(new RequestInterceptor()
+        {
+          @Override
+          public void apply(RequestTemplate template) {
+            template.header("User-Agent", userAgent);
+          }
+        })
+        .target(NexusIqApi.class, serverUrl);
+  }
+}

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
@@ -42,6 +42,8 @@ public class NexusIqPluginScanExtension
 
   private String applicationId;
 
+  private String organizationId;
+
   private boolean allConfigurations;
 
   private boolean simulationEnabled;
@@ -95,6 +97,14 @@ public class NexusIqPluginScanExtension
 
   public void setApplicationId(String applicationId) {
     this.applicationId = applicationId;
+  }
+
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+  public void setOrganizationId(String organizationId) {
+    this.organizationId = organizationId;
   }
 
   public String getScanFolderPath() {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
@@ -58,6 +58,7 @@ public class NexusIqPluginScanExtension
 
   public NexusIqPluginScanExtension(Project project) {
     stage = Stage.ID_BUILD;
+    organizationId = "";
     simulationEnabled = false;
     simulatedPolicyActionId = PolicyAction.NONE.toString();
     scanFolderPath = project.getBuildDir() + File.separator + SONATYPE_CLM_FOLDER + File.separator;

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
@@ -27,6 +27,7 @@ import com.sonatype.insight.brain.client.PolicyAction;
 import com.sonatype.insight.scan.module.model.Module;
 import com.sonatype.nexus.api.common.Authentication;
 import com.sonatype.nexus.api.common.ServerConfig;
+import com.sonatype.nexus.api.exception.IqClientException;
 import com.sonatype.nexus.api.iq.Action;
 import com.sonatype.nexus.api.iq.ApplicationPolicyEvaluation;
 import com.sonatype.nexus.api.iq.PolicyActionResolver;
@@ -39,6 +40,8 @@ import com.sonatype.nexus.api.iq.scan.ScanResult;
 
 import org.sonatype.gradle.plugins.scan.common.DependenciesFinder;
 import org.sonatype.gradle.plugins.scan.common.PluginVersionUtils;
+import org.sonatype.gradle.plugins.scan.nexus.iq.api.Application;
+import org.sonatype.gradle.plugins.scan.nexus.iq.api.NexusIqApi;
 
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.DefaultTask;
@@ -96,12 +99,7 @@ public class NexusIqScanTask
 
         iqClient.validateServerVersion(MINIMAL_SERVER_VERSION_REQUIRED);
 
-        if (!iqClient.verifyOrCreateApplication(extension.getApplicationId())) {
-          throw new IllegalArgumentException(String.format(
-              "Application ID %s doesn't exist and couldn't be created or the user %s doesn't have the "
-                  + "'Application Evaluator' role for that application.",
-              extension.getApplicationId(), extension.getUsername()));
-        }
+        verifyOrCreateApplication(iqClient);
 
         ProprietaryConfig proprietaryConfig =
             iqClient.getProprietaryConfigForApplicationEvaluation(extension.getApplicationId());
@@ -128,6 +126,31 @@ public class NexusIqScanTask
     }
     catch (Exception e) {
       throw new GradleException("Could not scan the project: " + e.getMessage(), e);
+    }
+  }
+
+  private void verifyOrCreateApplication(InternalIqClient iqClient) throws IqClientException {
+    if (StringUtils.isNoneBlank(extension.getOrganizationId(), extension.getApplicationId())) {
+      NexusIqApi nexusIqApi = NexusIqApi.build(extension.getServerUrl(), extension.getUsername(),
+          extension.getPassword(), buildUserAgent());
+
+      boolean applicationExists = nexusIqApi
+          .getApplicationsByOrganizationId(extension.getOrganizationId())
+          .getApplications()
+          .stream()
+          .anyMatch(application -> application.getName().equals(extension.getApplicationId()));
+
+      if (!applicationExists) {
+        Application application =
+            new Application(extension.getApplicationId(), extension.getApplicationId(), extension.getOrganizationId());
+        nexusIqApi.createApplication(application);
+      }
+    }
+    else if (!iqClient.verifyOrCreateApplication(extension.getApplicationId())) {
+      throw new IllegalArgumentException(String.format(
+          "Application ID %s doesn't exist and couldn't be created or the user %s doesn't have the "
+              + "'Application Evaluator' role for that application.",
+          extension.getApplicationId(), extension.getUsername()));
     }
   }
 
@@ -207,6 +230,11 @@ public class NexusIqScanTask
   @Input
   public String getApplicationId() {
     return extension.getApplicationId();
+  }
+
+  @Input
+  public String getOrganizationId() {
+    return extension.getOrganizationId();
   }
 
   @Input


### PR DESCRIPTION
Nexus IQ Server provides a feature where a non-existing application can be created automatically under a predefined organization: https://help.sonatype.com/iqserver/managing/application-management/managing-automatic-applications

Issue #82 exposed a use case where not all applications to be created automatically should be under the same organization.

This pull-requests adds this feature by using the public APIs from Nexus IQ Server to validate if an application exists under a given organization and creates it if none is found.

It relates to the following issue #s:
* Fixes #82 

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
