### PR TITLE
Fix commit hash discovery

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ Sonatype internal people:
 - [@hboutemy](https://github.com/hboutemy) (Hervé Boutemy)
 - [@maurycupitt](https://github.com/maurycupitt) (Maury Cupitt)
 - [@scherzhaft](https://github.com/scherzhaft) (Shane Stecker)
+- [@eduard-tita](https://github.com/eduard-tita) (Eduard Tita)
 
 External contributors:
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ nexusIQScan {
     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
     dirExcludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using '**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar'
     dirIncludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
+    scanFolderPath = '/path/to/project/root' // Optional. Defaults to the working directory (where gradle is executed). It's used to collect git information like commit hash and reposiroty URL 
 }
 ```
 
@@ -175,6 +176,7 @@ nexusIQScan {
     modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
     dirExcludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using "**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar"
     dirIncludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
+    scanFolderPath = "/path/to/project/root" // Optional. Defaults to the working directory (where gradle is executed). It's used to collect git information like commit hash and reposiroty URL
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -157,8 +157,7 @@ nexusIQScan {
     resultFilePath = 'results.json' // Optional. JSON file containing results of the evaluation
     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
     dirExcludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using '**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar'
-    dirIncludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
-    scanFolderPath = '/path/to/project/root' // Optional. Path to the project root, under which the '.git' folder usually resides. Defaults to the working directory (where gradle is executed).  
+    dirIncludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined  
 }
 ```
 
@@ -176,7 +175,6 @@ nexusIQScan {
     modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
     dirExcludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using "**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar"
     dirIncludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
-    scanFolderPath = "/path/to/project/root" // Optional. Path to the project root, under which the '.git' folder usually resides. Defaults to the working directory (where gradle is executed).
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ nexusIQScan {
     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
     dirExcludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using '**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar'
     dirIncludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
-    scanFolderPath = '/path/to/project/root' // Optional. Defaults to the working directory (where gradle is executed). It's used to collect git information like commit hash and reposiroty URL 
+    scanFolderPath = '/path/to/project/root' // Optional. Path to the project root, under which the '.git' folder usually resides. Defaults to the working directory (where gradle is executed).  
 }
 ```
 
@@ -176,7 +176,7 @@ nexusIQScan {
     modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
     dirExcludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using "**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar"
     dirIncludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
-    scanFolderPath = "/path/to/project/root" // Optional. Defaults to the working directory (where gradle is executed). It's used to collect git information like commit hash and reposiroty URL
+    scanFolderPath = "/path/to/project/root" // Optional. Path to the project root, under which the '.git' folder usually resides. Defaults to the working directory (where gradle is executed).
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ nexusIQScan {
     resultFilePath = 'results.json' // Optional. JSON file containing results of the evaluation
     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
     dirExcludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using '**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar'
-    dirIncludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined  
+    dirIncludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
 }
 ```
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
@@ -15,7 +15,6 @@
  */
 package org.sonatype.gradle.plugins.scan.nexus.iq.scan;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.Set;
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
@@ -60,7 +60,7 @@ public class NexusIqPluginScanExtension
     organizationId = "";
     simulationEnabled = false;
     simulatedPolicyActionId = PolicyAction.NONE.toString();
-    scanFolderPath = System.getProperty("user.dir");
+    scanFolderPath = project.getRootDir().getAbsolutePath();
     modulesExcluded = Collections.emptySet();
     dirIncludes = "";
     dirExcludes = "";

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
@@ -61,7 +61,7 @@ public class NexusIqPluginScanExtension
     organizationId = "";
     simulationEnabled = false;
     simulatedPolicyActionId = PolicyAction.NONE.toString();
-    scanFolderPath = project.getBuildDir() + File.separator + SONATYPE_CLM_FOLDER + File.separator;
+    scanFolderPath = System.getProperty("user.dir");
     modulesExcluded = Collections.emptySet();
     dirIncludes = "";
     dirExcludes = "";


### PR DESCRIPTION
This pull request makes the following changes:
* Provide a better default value for the `scanFolderPath` field in `NexusIqPluginScanExtension` (the current value will never work).
* Document how to set the `scanFolderPath` field in order to properly collect the commit hash during scans.

It relates to the following issue #s:
* Fixes #92 

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
