### PR TITLE
Introduce 'modulesExcluded' property for ossIndexAudit

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ ossIndexAudit {
     }
     showAll = false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
     printBanner = true // if true will print ASCII text banner. By default is true.
-    modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing.
+    modulesIncluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to include for auditing. If not specified all modules are included.
+    modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing. If not specified no modules are excluded. This value is processed after 'modulesIncluded' if both are specified.
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
     excludeVulnerabilityIds = ['39d74cc8-457a-4e57-89ef-a258420138c5'] // list containing ids of vulnerabilities to be ignored
@@ -129,7 +130,8 @@ ossIndexAudit {
     isShowAll =
         false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
     isPrintBanner = true // if true will print ASCII text banner. By default is true.
-    modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing.
+    modulesIncluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to include for auditing. If not specified all modules are included.
+    modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing. If not specified no modules are excluded. This value is processed after 'modulesIncluded' if both are specified.
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
     excludeVulnerabilityIds =

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ ossIndexAudit {
     }
     showAll = false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
     printBanner = true // if true will print ASCII text banner. By default is true.
+    modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing.
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
     excludeVulnerabilityIds = ['39d74cc8-457a-4e57-89ef-a258420138c5'] // list containing ids of vulnerabilities to be ignored
@@ -128,6 +129,7 @@ ossIndexAudit {
     isShowAll =
         false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
     isPrintBanner = true // if true will print ASCII text banner. By default is true.
+    modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing.
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
     excludeVulnerabilityIds =

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.gradle.api.tasks.Optional;
 import org.sonatype.goodies.packageurl.PackageUrl;
 import org.sonatype.goodies.packageurl.PackageUrlBuilder;
 import org.sonatype.gradle.plugins.scan.common.DependenciesFinder;
@@ -251,11 +252,13 @@ public class OssIndexAuditTask
   }
 
   @Input
+  @Optional
   public Set<String> getModulesIncluded() {
     return extension.getModulesIncluded();
   }
 
   @Input
+  @Optional
   public Set<String> getModulesExcluded() {
     return extension.getModulesExcluded();
   }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -73,6 +73,7 @@ public class OssIndexAuditTask
 
     try (OssindexClient ossIndexClient = buildOssIndexClient()) {
       Set<ResolvedDependency> dependencies = getProject().getAllprojects().stream()
+          .filter(project -> extension.getModulesExcluded() == null || !extension.getModulesExcluded().contains(project.getName()))
           .flatMap(
               project -> dependenciesFinder.findResolvedDependencies(project, extension.isAllConfigurations()).stream())
           .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -249,4 +249,14 @@ public class OssIndexAuditTask
   public boolean isPrintBanner() {
     return extension.isPrintBanner();
   }
+
+  @Input
+  public Set<String> getModulesIncluded() {
+    return extension.getModulesIncluded();
+  }
+
+  @Input
+  public Set<String> getModulesExcluded() {
+    return extension.getModulesExcluded();
+  }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -73,6 +73,7 @@ public class OssIndexAuditTask
 
     try (OssindexClient ossIndexClient = buildOssIndexClient()) {
       Set<ResolvedDependency> dependencies = getProject().getAllprojects().stream()
+          .filter(project -> extension.getModulesIncluded() == null || extension.getModulesIncluded().isEmpty() || extension.getModulesIncluded().contains(project.getName()))
           .filter(project -> extension.getModulesExcluded() == null || !extension.getModulesExcluded().contains(project.getName()))
           .flatMap(
               project -> dependenciesFinder.findResolvedDependencies(project, extension.isAllConfigurations()).stream())

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -44,6 +44,8 @@ public class OssIndexPluginExtension
 
   private boolean allConfigurations;
 
+  private Set<String> modulesIncluded;
+
   private Set<String> modulesExcluded;
 
   private boolean simulationEnabled;
@@ -126,6 +128,14 @@ public class OssIndexPluginExtension
 
   public void setAllConfigurations(boolean allConfigurations) {
     this.allConfigurations = allConfigurations;
+  }
+
+  public Set<String> getModulesIncluded() {
+    return modulesIncluded;
+  }
+
+  public void setModulesIncluded(Set<String> modulesIncluded) {
+    this.modulesIncluded = modulesIncluded;
   }
 
   public Set<String> getModulesExcluded() {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -44,6 +44,8 @@ public class OssIndexPluginExtension
 
   private boolean allConfigurations;
 
+  private Set<String> modulesExcluded;
+
   private boolean simulationEnabled;
 
   private boolean simulatedVulnerabilityFound;
@@ -124,6 +126,14 @@ public class OssIndexPluginExtension
 
   public void setAllConfigurations(boolean allConfigurations) {
     this.allConfigurations = allConfigurations;
+  }
+
+  public Set<String> getModulesExcluded() {
+    return modulesExcluded;
+  }
+
+  public void setModulesExcluded(Set<String> modulesExcluded) {
+    this.modulesExcluded = modulesExcluded;
   }
 
   public boolean isSimulationEnabled() {

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
@@ -48,7 +48,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -92,14 +93,15 @@ public class OssIndexAuditTaskTest
   }
 
   @Test
-  public void testAudit_verifyModulesIncludedExist() throws Exception {
+  public void testAudit_verifyModulesIncludedIsApplied() throws Exception {
     setupComponentReport(true);
     OssIndexAuditTask taskSpy = buildAuditTaskSpy(false, (project, extension) -> extension.setModulesIncluded(Collections.singleton("does-not-exist")));
     
-    assertThatThrownBy(taskSpy::audit)
-        .isInstanceOf(GradleException.class)
-        .hasMessageContaining("Could not audit the project: One or more coordinates required");
-
+    taskSpy.audit();
+    
+    // Note: in the non-mock implementation the audit() method would throw a GradleException with the
+    // message "Could not audit the project: One or more coordinates required"
+    verify(ossIndexClientMock, never()).requestComponentReports(null);
   }
 
   @Test
@@ -109,11 +111,12 @@ public class OssIndexAuditTaskTest
       extension.setModulesIncluded(Collections.singleton(project.getName()));
       extension.setModulesExcluded(Collections.singleton(project.getName()));
     });
-    
-    assertThatThrownBy(taskSpy::audit)
-        .isInstanceOf(GradleException.class)
-        .hasMessageContaining("Could not audit the project: One or more coordinates required");
 
+    taskSpy.audit();
+
+    // Note: in the non-mock implementation the audit() method would throw a GradleException with the
+    // message "Could not audit the project: One or more coordinates required"
+    verify(ossIndexClientMock, never()).requestComponentReports(null);
   }
 
   @Test

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
@@ -91,6 +91,16 @@ public class OssIndexAuditTaskTest
   }
 
   @Test
+  public void testAudit_novulnerabilitiesBecauseModuleExcluded() throws Exception {
+    setupComponentReport(true);
+    OssIndexAuditTask taskSpy = buildAuditTaskSpy(false);
+
+    taskSpy.getExtensions().findByType(OssIndexPluginExtension.class).setModulesExcluded(Collections.singleton(taskSpy.getProject().getName()));
+    
+    taskSpy.audit();
+  }
+
+  @Test
   public void testAudit_simulated() throws Exception {
     OssIndexAuditTask taskSpy = buildAuditTaskSpy(true);
     taskSpy.audit();


### PR DESCRIPTION
Similar to the property of the same name for nexusIQScan. Changes are as suggested by @guillermo-varela in issue #109.

Fixes #109 

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
