### PR TITLE
CycloneDX to generate a JSON result for OSS Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ ossIndexAudit {
     excludeCoordinates = ['commons-fileupload:commons-fileupload:1.3'] // list containing coordinate of components which if vulnerable should be ignored
 
     // Output options
-    outputFormat = 'DEFAULT' // Optional, other values are: 'DEPENDENCY_GRAPH' prints dependency graph showing direct/transitive dependencies, 'JSON_CYCLONE_DX_14' prints a CycloneDX 1.4 SBOM in JSON format.
+    outputFormat = 'DEFAULT' // Optional, other values are: 'DEPENDENCY_GRAPH' prints dependency graph showing direct/transitive dependencies, 'JSON_CYCLONE_DX_1_4' prints a CycloneDX 1.4 SBOM in JSON format.
+    cycloneDxComponentType = 'LIBRARY' // Optional, only used when outputFormat = 'JSON_CYCLONE_DX_1_4' to define the type of component this project is for the BOM metadata with possible values: 'LIBRARY' (default), 'APPLICATION', 'FRAMEWORK', 'CONTAINER', 'OPERATING_SYSTEM', 'DEVICE', 'FIRMWARE' and 'FILE'.
     isColorEnabled = false // if true (and outputFormat = "DEFAULT") prints vulnerability description in color. By default is true.
     showAll = false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
     printBanner = true // if true will print ASCII text banner. By default is true.
@@ -136,7 +137,8 @@ ossIndexAudit {
         listOf("commons-fileupload:commons-fileupload:1.3") // list containing coordinate of components which if vulnerable should be ignored
 
     // Output options
-    outputFormat = "DEFAULT" // Optional, other values are: "DEPENDENCY_GRAPH" prints dependency graph showing direct/transitive dependencies, "JSON_CYCLONE_DX_14" prints a CycloneDX 1.4 SBOM in JSON format.
+    outputFormat = "DEFAULT" // Optional, other values are: "DEPENDENCY_GRAPH" prints dependency graph showing direct/transitive dependencies, "JSON_CYCLONE_DX_1_4" prints a CycloneDX 1.4 SBOM in JSON format.
+    cycloneDxComponentType = "LIBRARY" // Optional, only used when outputFormat = "JSON_CYCLONE_DX_1_4" to define the type of component this project is for the BOM metadata with possible values: "LIBRARY" (default), "APPLICATION", "FRAMEWORK", "CONTAINER", "OPERATING_SYSTEM", "DEVICE", "FIRMWARE" and "FILE".
     isColorEnabled = false // if true (and outputFormat = "DEFAULT") prints vulnerability description in color. By default is true.
     isShowAll = false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
     isPrintBanner = true // if true will print ASCII text banner. By default is true.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ ossIndexAudit {
     excludeCoordinates = ['commons-fileupload:commons-fileupload:1.3'] // list containing coordinate of components which if vulnerable should be ignored
 
     // Output options
-    outputFormat = "DEFAULT" // Optional, other values are: "DEPENDENCY_GRAPH" prints dependency graph showing direct/transitive dependencies, "JSON_CYCLONE_DX_14" prints a CycloneDX 1.4 SBOM in JSON format.
+    outputFormat = 'DEFAULT' // Optional, other values are: 'DEPENDENCY_GRAPH' prints dependency graph showing direct/transitive dependencies, 'JSON_CYCLONE_DX_14' prints a CycloneDX 1.4 SBOM in JSON format.
     isColorEnabled = false // if true (and outputFormat = "DEFAULT") prints vulnerability description in color. By default is true.
     showAll = false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
     printBanner = true // if true will print ASCII text banner. By default is true.

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Gradle can be used to build projects developed in various programming languages.
 
 ```
 plugins {
-  id 'org.sonatype.gradle.plugins.scan' version '2.3.0' // Update the version as needed
+  id 'org.sonatype.gradle.plugins.scan' version '2.4.0' // Update the version as needed
 }
 ```
 
 - Or `build.gradle.kts`:
 ```
 plugins {
-    id ("org.sonatype.gradle.plugins.scan") version "2.3.0" // Update the version as needed
+    id ("org.sonatype.gradle.plugins.scan") version "2.4.0" // Update the version as needed
 }
 ```
 
@@ -86,8 +86,6 @@ ossIndexAudit {
     useCache = true // true by default
     cacheDirectory = 'some/path' // by default it uses the user data directory (according to OS)
     cacheExpiration = 'PT12H' // 12 hours if omitted. It must follow the Joda Time specification at https://www.javadoc.io/doc/joda-time/joda-time/2.10.4/org/joda/time/Duration.html#parse-java.lang.String-
-    colorEnabled = false // if true prints vulnerability description in color. By default is true.
-    dependencyGraph = false // if true prints dependency graph showing direct/transitive dependencies. By default is false.
     proxyConfiguration { // extra configuration when running behind a proxy without direct internet access
         protocol = 'http' // can be 'http' (default) or 'https'
         host = 'proxy-host' // hostname for the proxy
@@ -95,14 +93,18 @@ ossIndexAudit {
         authConfiguration.username = 'username' // username for the proxy (if credentials are required)
         authConfiguration.password = 'password' // password for the proxy (if credentials are required)
     }
-    showAll = false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
-    printBanner = true // if true will print ASCII text banner. By default is true.
     modulesIncluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to include for auditing. If not specified all modules are included.
     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing. If not specified no modules are excluded. This value is processed after 'modulesIncluded' if both are specified.
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
     excludeVulnerabilityIds = ['39d74cc8-457a-4e57-89ef-a258420138c5'] // list containing ids of vulnerabilities to be ignored
     excludeCoordinates = ['commons-fileupload:commons-fileupload:1.3'] // list containing coordinate of components which if vulnerable should be ignored
+
+    // Output options
+    outputFormat = "DEFAULT" // Optional, other values are: "DEPENDENCY_GRAPH" prints dependency graph showing direct/transitive dependencies, "JSON_CYCLONE_DX_14" prints a CycloneDX 1.4 SBOM in JSON format.
+    isColorEnabled = false // if true (and outputFormat = "DEFAULT") prints vulnerability description in color. By default is true.
+    showAll = false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
+    printBanner = true // if true will print ASCII text banner. By default is true.
 }
 ```
 
@@ -117,9 +119,6 @@ ossIndexAudit {
     cacheDirectory = "some/path" // by default it uses the user data directory (according to OS)
     cacheExpiration =
         "PT12H" // 12 hours if omitted. It must follow the Joda Time specification at https://www.javadoc.io/doc/joda-time/joda-time/2.10.4/org/joda/time/Duration.html#parse-java.lang.String-
-    isColorEnabled = false // if true prints vulnerability description in color. By default is true.
-    isDependencyGraph =
-        false // if true prints dependency graph showing direct/transitive dependencies. By default is false.
     proxyConfiguration { // extra configuration when running behind a proxy without direct internet access
         protocol = "http" // can be "http" (default) or "https"
         host = "proxy-host" // hostname for the proxy
@@ -127,9 +126,6 @@ ossIndexAudit {
         authConfiguration.username = "username" // username for the proxy (if credentials are required)
         authConfiguration.password = "password" // password for the proxy (if credentials are required)
     }
-    isShowAll =
-        false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
-    isPrintBanner = true // if true will print ASCII text banner. By default is true.
     modulesIncluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to include for auditing. If not specified all modules are included.
     modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing. If not specified no modules are excluded. This value is processed after 'modulesIncluded' if both are specified.
 
@@ -138,6 +134,12 @@ ossIndexAudit {
         listOf("39d74cc8-457a-4e57-89ef-a258420138c5") // list containing ids of vulnerabilities to be ignored
     excludeCoordinates =
         listOf("commons-fileupload:commons-fileupload:1.3") // list containing coordinate of components which if vulnerable should be ignored
+
+    // Output options
+    outputFormat = "DEFAULT" // Optional, other values are: "DEPENDENCY_GRAPH" prints dependency graph showing direct/transitive dependencies, "JSON_CYCLONE_DX_14" prints a CycloneDX 1.4 SBOM in JSON format.
+    isColorEnabled = false // if true (and outputFormat = "DEFAULT") prints vulnerability description in color. By default is true.
+    isShowAll = false // if true prints all dependencies. By default is false, meaning only dependencies with vulnerabilities will be printed.
+    isPrintBanner = true // if true will print ASCII text banner. By default is true.
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ dependencies {
   implementation "io.github.openfeign:feign-core:$feignVersion"
   implementation "io.github.openfeign:feign-gson:$feignVersion"
   implementation "com.google.code.gson:gson:$gsonVersion"
+  implementation "ch.qos.logback:logback-classic:$logbackVersion"
 
   testImplementation gradleTestKit()
   testImplementation "junit:junit:$junitVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,11 +15,11 @@
 #
 
 group=org.sonatype.gradle.plugins
-version=2.3.1-SNAPSHOT
+version=2.4.0-SNAPSHOT
 release.useAutomaticVersion=true
 
 nexusPlatformApiVersion=3.48.8-01
-ossIndexClientVersion=1.7.0
+ossIndexClientVersion=1.8.1
 feignVersion=11.7
 gsonVersion=2.8.9
 logbackVersion=1.2.11

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,10 +18,11 @@ group=org.sonatype.gradle.plugins
 version=2.3.1-SNAPSHOT
 release.useAutomaticVersion=true
 
-nexusPlatformApiVersion=3.37
+nexusPlatformApiVersion=3.48.8-01
 ossIndexClientVersion=1.7.0
 feignVersion=11.7
 gsonVersion=2.8.9
+logbackVersion=1.2.11
 
 junitVersion=4.13.2
 powermockVersion=2.0.9

--- a/nexus-platform-api/build.gradle
+++ b/nexus-platform-api/build.gradle
@@ -35,5 +35,5 @@ artifacts {
 }
 
 dependencies {
-  implementation "com.sonatype.nexus:nexus-platform-api:$nexusPlatformApiVersion:internal"
+  implementation "com.sonatype.nexus:nexus-platform-api:$nexusPlatformApiVersion"
 }

--- a/src/integTest/resources/android-multiple-flavors/build.gradle
+++ b/src/integTest/resources/android-multiple-flavors/build.gradle
@@ -49,6 +49,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
   showAll = true
 }

--- a/src/integTest/resources/android-multiple-flavors/build.gradle
+++ b/src/integTest/resources/android-multiple-flavors/build.gradle
@@ -49,6 +49,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
   showAll = true
 }

--- a/src/integTest/resources/android/build.gradle
+++ b/src/integTest/resources/android/build.gradle
@@ -48,6 +48,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
   showAll = true
 }

--- a/src/integTest/resources/android/build.gradle
+++ b/src/integTest/resources/android/build.gradle
@@ -48,6 +48,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
   showAll = true
 }

--- a/src/integTest/resources/control_cycloneDx.gradle
+++ b/src/integTest/resources/control_cycloneDx.gradle
@@ -20,6 +20,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = 'JSON_CYCLONE_DX_14'
+  outputFormat = 'JSON_CYCLONE_DX_1_4'
   showAll = true
 }

--- a/src/integTest/resources/control_cycloneDx.gradle
+++ b/src/integTest/resources/control_cycloneDx.gradle
@@ -20,6 +20,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "JSON_CYCLONE_DX_14"
+  outputFormat = 'JSON_CYCLONE_DX_14'
   showAll = true
 }

--- a/src/integTest/resources/control_cycloneDx.gradle
+++ b/src/integTest/resources/control_cycloneDx.gradle
@@ -7,7 +7,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  compile 'commons-collections:commons-collections:3.1'
+  implementation 'commons-collections:commons-collections:3.1'
 }
 
 nexusIQScan {
@@ -20,6 +20,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = "JSON_CYCLONE_DX_14"
   showAll = true
 }

--- a/src/integTest/resources/control_cycloneDx_not_all.gradle
+++ b/src/integTest/resources/control_cycloneDx_not_all.gradle
@@ -20,5 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = 'JSON_CYCLONE_DX_14'
+  outputFormat = 'JSON_CYCLONE_DX_1_4'
 }

--- a/src/integTest/resources/control_cycloneDx_not_all.gradle
+++ b/src/integTest/resources/control_cycloneDx_not_all.gradle
@@ -20,5 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "JSON_CYCLONE_DX_14"
+  outputFormat = 'JSON_CYCLONE_DX_14'
 }

--- a/src/integTest/resources/control_cycloneDx_not_all.gradle
+++ b/src/integTest/resources/control_cycloneDx_not_all.gradle
@@ -7,7 +7,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  compile 'commons-collections:commons-collections:3.1'
+  implementation 'commons-collections:commons-collections:3.1'
 }
 
 nexusIQScan {
@@ -20,6 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
-  showAll = true
+  outputFormat = "JSON_CYCLONE_DX_14"
 }

--- a/src/integTest/resources/control_dependency_graph.gradle
+++ b/src/integTest/resources/control_dependency_graph.gradle
@@ -20,6 +20,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
   showAll = true
 }

--- a/src/integTest/resources/control_dependency_graph.gradle
+++ b/src/integTest/resources/control_dependency_graph.gradle
@@ -20,6 +20,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
   showAll = true
 }

--- a/src/integTest/resources/control_dependency_graph_not_all.gradle
+++ b/src/integTest/resources/control_dependency_graph_not_all.gradle
@@ -20,5 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
 }

--- a/src/integTest/resources/control_dependency_graph_not_all.gradle
+++ b/src/integTest/resources/control_dependency_graph_not_all.gradle
@@ -20,5 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
 }

--- a/src/integTest/resources/exclude-test-dependency-graph.gradle
+++ b/src/integTest/resources/exclude-test-dependency-graph.gradle
@@ -13,5 +13,5 @@ dependencies {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
 }

--- a/src/integTest/resources/exclude-test-dependency-graph.gradle
+++ b/src/integTest/resources/exclude-test-dependency-graph.gradle
@@ -13,5 +13,5 @@ dependencies {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
 }

--- a/src/integTest/resources/include-test-dependency-graph.gradle
+++ b/src/integTest/resources/include-test-dependency-graph.gradle
@@ -14,6 +14,6 @@ dependencies {
 ossIndexAudit {
   allConfigurations = true
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
   showAll = true
 }

--- a/src/integTest/resources/include-test-dependency-graph.gradle
+++ b/src/integTest/resources/include-test-dependency-graph.gradle
@@ -14,6 +14,6 @@ dependencies {
 ossIndexAudit {
   allConfigurations = true
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
   showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/android-multiple-flavors/build.gradle
+++ b/src/integTest/resources/legacy-syntax/android-multiple-flavors/build.gradle
@@ -37,7 +37,7 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
   showAll = true
   allConfigurations = true
 }

--- a/src/integTest/resources/legacy-syntax/android-multiple-flavors/build.gradle
+++ b/src/integTest/resources/legacy-syntax/android-multiple-flavors/build.gradle
@@ -37,7 +37,7 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
   showAll = true
   allConfigurations = true
 }

--- a/src/integTest/resources/legacy-syntax/android/build.gradle
+++ b/src/integTest/resources/legacy-syntax/android/build.gradle
@@ -37,6 +37,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
   showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/android/build.gradle
+++ b/src/integTest/resources/legacy-syntax/android/build.gradle
@@ -37,6 +37,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
   showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/control_cycloneDx.gradle
+++ b/src/integTest/resources/legacy-syntax/control_cycloneDx.gradle
@@ -20,6 +20,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = 'JSON_CYCLONE_DX_14'
+  outputFormat = 'JSON_CYCLONE_DX_1_4'
   showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/control_cycloneDx.gradle
+++ b/src/integTest/resources/legacy-syntax/control_cycloneDx.gradle
@@ -20,6 +20,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "JSON_CYCLONE_DX_14"
+  outputFormat = 'JSON_CYCLONE_DX_14'
   showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/control_cycloneDx.gradle
+++ b/src/integTest/resources/legacy-syntax/control_cycloneDx.gradle
@@ -20,6 +20,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = "JSON_CYCLONE_DX_14"
   showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/control_cycloneDx_not_all.gradle
+++ b/src/integTest/resources/legacy-syntax/control_cycloneDx_not_all.gradle
@@ -20,5 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = 'JSON_CYCLONE_DX_14'
+  outputFormat = 'JSON_CYCLONE_DX_1_4'
 }

--- a/src/integTest/resources/legacy-syntax/control_cycloneDx_not_all.gradle
+++ b/src/integTest/resources/legacy-syntax/control_cycloneDx_not_all.gradle
@@ -20,5 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "JSON_CYCLONE_DX_14"
+  outputFormat = 'JSON_CYCLONE_DX_14'
 }

--- a/src/integTest/resources/legacy-syntax/control_cycloneDx_not_all.gradle
+++ b/src/integTest/resources/legacy-syntax/control_cycloneDx_not_all.gradle
@@ -20,6 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
-  showAll = true
+  outputFormat = "JSON_CYCLONE_DX_14"
 }

--- a/src/integTest/resources/legacy-syntax/control_dependency_graph.gradle
+++ b/src/integTest/resources/legacy-syntax/control_dependency_graph.gradle
@@ -20,6 +20,6 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
   showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/control_dependency_graph_not_all.gradle
+++ b/src/integTest/resources/legacy-syntax/control_dependency_graph_not_all.gradle
@@ -20,5 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
 }

--- a/src/integTest/resources/legacy-syntax/control_dependency_graph_not_all.gradle
+++ b/src/integTest/resources/legacy-syntax/control_dependency_graph_not_all.gradle
@@ -20,5 +20,5 @@ nexusIQScan {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
 }

--- a/src/integTest/resources/legacy-syntax/exclude-test-dependency-graph.gradle
+++ b/src/integTest/resources/legacy-syntax/exclude-test-dependency-graph.gradle
@@ -13,5 +13,5 @@ dependencies {
 
 ossIndexAudit {
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
 }

--- a/src/integTest/resources/legacy-syntax/exclude-test-dependency-graph.gradle
+++ b/src/integTest/resources/legacy-syntax/exclude-test-dependency-graph.gradle
@@ -13,5 +13,5 @@ dependencies {
 
 ossIndexAudit {
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
 }

--- a/src/integTest/resources/legacy-syntax/include-test-dependency-graph.gradle
+++ b/src/integTest/resources/legacy-syntax/include-test-dependency-graph.gradle
@@ -14,6 +14,6 @@ dependencies {
 ossIndexAudit {
   allConfigurations = true
   simulationEnabled = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
   showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/include-test-dependency-graph.gradle
+++ b/src/integTest/resources/legacy-syntax/include-test-dependency-graph.gradle
@@ -14,6 +14,6 @@ dependencies {
 ossIndexAudit {
   allConfigurations = true
   simulationEnabled = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
   showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/policy-fail_dependency_graph.gradle
+++ b/src/integTest/resources/legacy-syntax/policy-fail_dependency_graph.gradle
@@ -22,5 +22,5 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   simulatedVulnerabilityFound = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
 }

--- a/src/integTest/resources/legacy-syntax/policy-fail_dependency_graph.gradle
+++ b/src/integTest/resources/legacy-syntax/policy-fail_dependency_graph.gradle
@@ -22,5 +22,5 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   simulatedVulnerabilityFound = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
 }

--- a/src/integTest/resources/legacy-syntax/transitive-dependencies.gradle
+++ b/src/integTest/resources/legacy-syntax/transitive-dependencies.gradle
@@ -11,6 +11,6 @@ dependencies {
 }
 ossIndexAudit {
   colorEnabled = false
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
   showAll = true
 }

--- a/src/integTest/resources/legacy-syntax/transitive-dependencies.gradle
+++ b/src/integTest/resources/legacy-syntax/transitive-dependencies.gradle
@@ -11,6 +11,6 @@ dependencies {
 }
 ossIndexAudit {
   colorEnabled = false
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
   showAll = true
 }

--- a/src/integTest/resources/policy-fail_dependency_graph.gradle
+++ b/src/integTest/resources/policy-fail_dependency_graph.gradle
@@ -22,5 +22,5 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   simulatedVulnerabilityFound = true
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
 }

--- a/src/integTest/resources/policy-fail_dependency_graph.gradle
+++ b/src/integTest/resources/policy-fail_dependency_graph.gradle
@@ -22,5 +22,5 @@ nexusIQScan {
 ossIndexAudit {
   simulationEnabled = true
   simulatedVulnerabilityFound = true
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
 }

--- a/src/integTest/resources/transitive-dependencies.gradle
+++ b/src/integTest/resources/transitive-dependencies.gradle
@@ -11,6 +11,6 @@ dependencies {
 }
 ossIndexAudit {
   colorEnabled = false
-  outputFormat = "DEPENDENCY_GRAPH"
+  outputFormat = 'DEPENDENCY_GRAPH'
   showAll = true
 }

--- a/src/integTest/resources/transitive-dependencies.gradle
+++ b/src/integTest/resources/transitive-dependencies.gradle
@@ -11,6 +11,6 @@ dependencies {
 }
 ossIndexAudit {
   colorEnabled = false
-  dependencyGraph = true
+  outputFormat = "DEPENDENCY_GRAPH"
   showAll = true
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -28,9 +28,9 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.sonatype.insight.scan.module.model.Artifact;
-import com.sonatype.insight.scan.module.model.Dependency;
-import com.sonatype.insight.scan.module.model.Module;
+import hidden.com.sonatype.insight.scan.module.model.Artifact;
+import hidden.com.sonatype.insight.scan.module.model.Dependency;
+import hidden.com.sonatype.insight.scan.module.model.Module;
 
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import com.sonatype.insight.scan.module.model.Module;
-import com.sonatype.insight.scan.module.model.io.ModuleIoManager;
+import hidden.com.sonatype.insight.scan.module.model.Module;
+import hidden.com.sonatype.insight.scan.module.model.io.ModuleIoManager;
 
 import org.sonatype.gradle.plugins.scan.common.DependenciesFinder;
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
@@ -24,7 +24,6 @@ import java.util.Properties;
 import java.util.Set;
 
 import com.sonatype.insight.brain.client.PolicyAction;
-import com.sonatype.insight.scan.module.model.Module;
 import com.sonatype.nexus.api.common.Authentication;
 import com.sonatype.nexus.api.common.ServerConfig;
 import com.sonatype.nexus.api.exception.IqClientException;
@@ -43,6 +42,7 @@ import org.sonatype.gradle.plugins.scan.common.PluginVersionUtils;
 import org.sonatype.gradle.plugins.scan.nexus.iq.api.Application;
 import org.sonatype.gradle.plugins.scan.nexus.iq.api.NexusIqApi;
 
+import hidden.com.sonatype.insight.scan.module.model.Module;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.ossindex;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+
+import org.sonatype.goodies.packageurl.PackageUrl;
+import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
+import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerability;
+
+import nexus.shadow.org.cyclonedx.BomGeneratorFactory;
+import nexus.shadow.org.cyclonedx.CycloneDxSchema;
+import nexus.shadow.org.cyclonedx.generators.json.BomJsonGenerator;
+import nexus.shadow.org.cyclonedx.model.Bom;
+import nexus.shadow.org.cyclonedx.model.Component;
+import nexus.shadow.org.cyclonedx.model.ExtensibleType;
+import nexus.shadow.org.cyclonedx.model.Extension;
+import nexus.shadow.org.cyclonedx.model.Extension.ExtensionType;
+import nexus.shadow.org.cyclonedx.model.Source;
+import nexus.shadow.org.cyclonedx.model.vulnerability.Rating;
+import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability10;
+import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability10.Score;
+import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability10.Severity;
+import org.gradle.api.artifacts.ResolvedDependency;
+
+public class CycloneDxResponseHandler
+    implements OssIndexResponseHandler
+{
+  private final OssIndexPluginExtension extension;
+
+  public CycloneDxResponseHandler(OssIndexPluginExtension extension) {
+    this.extension = extension;
+  }
+
+  @Override
+  public boolean handleOssIndexResponse(
+      Set<ResolvedDependency> dependencies,
+      Map<ResolvedDependency, PackageUrl> dependenciesMap,
+      Map<PackageUrl, ComponentReport> response)
+  {
+    boolean hasVulnerabilities = false;
+    int dependenciesCount = dependenciesMap.size();
+
+    if (!extension.isShowAll()) {
+      dependenciesCount = (int) dependenciesMap.values().parallelStream()
+          .filter(packageUrl -> !response.get(packageUrl).getVulnerabilities().isEmpty())
+          .count();
+
+      if (dependenciesCount == 0) {
+        log.info("No vulnerabilities found!");
+      }
+      else {
+        log.info("Found vulnerabilities in {} dependencies", dependenciesCount);
+      }
+    }
+
+    Bom bom = new Bom();
+
+    for (Entry<ResolvedDependency, PackageUrl> entry : dependenciesMap.entrySet()) {
+      PackageUrl packageUrl = entry.getValue();
+      ComponentReport componentReport = response.get(packageUrl);
+
+      if (componentReport != null) {
+        List<ComponentReportVulnerability> vulnerabilities = componentReport.getVulnerabilities();
+        if (!vulnerabilities.isEmpty() || extension.isShowAll()) {
+          Component component = new Component();
+          component.setType(Component.Type.LIBRARY);
+          component.setGroup(packageUrl.getNamespaceAsString());
+          component.setName(packageUrl.getName());
+          component.setVersion(packageUrl.getVersion());
+          component.setPurl(packageUrl.toString());
+          component.setBomRef(packageUrl.toString());
+
+          List<ExtensibleType> extensions = new ArrayList<>();
+
+          for (ComponentReportVulnerability vulnerability : vulnerabilities) {
+            Vulnerability10 vulnerability10 = new Vulnerability10(component.getGroup(), component.getName());
+            vulnerability10.setId(vulnerability.getId());
+            vulnerability10.setRef(packageUrl.toString());
+            vulnerability10.setDescription(vulnerability.getDescription());
+
+            Score score = new Score();
+            Double base = Double.valueOf(vulnerability.getCvssScore());
+            score.setBase(base);
+
+            Rating rating = new Rating();
+            rating.setScore(score);
+            rating.setSeverity(Severity.fromString(VulnerabilityUtils.getAssessment(vulnerability.getCvssScore())));
+            rating.setVector(Objects.toString(vulnerability.getCvssVector(), "Unspecified"));
+            vulnerability10.setRatings(Collections.singletonList(rating));
+
+            Source source = new Source();
+            source.setName("OSS Index");
+            try {
+              source.setUrl(vulnerability.getReference().toURL());
+            }
+            catch (MalformedURLException e) {
+              log.error("Error processing the vulnerability URL: {}", vulnerability.getReference());
+            }
+            vulnerability10.setSource(source);
+
+            extensions.add(vulnerability10);
+          }
+
+          Extension extension = new Extension(ExtensionType.VULNERABILITIES, extensions);
+          bom.addComponent(component);
+          bom.add(ExtensionType.VULNERABILITIES.getTypeName(), extension);
+        }
+
+        if (!vulnerabilities.isEmpty()) {
+          hasVulnerabilities = true;
+        }
+      }
+    }
+
+    BomJsonGenerator generator = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_13, bom);
+    log.info(generator.toJsonString());
+
+    return hasVulnerabilities;
+  }
+}

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
@@ -15,6 +15,10 @@
  */
 package org.sonatype.gradle.plugins.scan.ossindex;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -46,11 +50,14 @@ import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability.Version;
 import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability.Version.Status;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.gradle.api.UncheckedIOException;
 import org.gradle.api.artifacts.ResolvedDependency;
 
 public class CycloneDxResponseHandler
     implements OssIndexResponseHandler
 {
+  public static final String FILE_NAME_OUTPUT = "oss-index-cyclonedx.json";
+
   private final OssIndexPluginExtension extension;
 
   public CycloneDxResponseHandler(OssIndexPluginExtension extension) {
@@ -72,6 +79,7 @@ public class CycloneDxResponseHandler
 
       if (dependenciesCount == 0) {
         log.info("No vulnerabilities found!");
+        return false;
       }
       else {
         log.info("Found vulnerabilities in {} dependencies", dependenciesCount);
@@ -89,36 +97,18 @@ public class CycloneDxResponseHandler
         List<ComponentReportVulnerability> componentVulnerabilities = componentReport.getVulnerabilities();
 
         if (!componentVulnerabilities.isEmpty() || extension.isShowAll()) {
-          Component component = new Component();
-          component.setType(Component.Type.LIBRARY);
-          component.setGroup(packageUrl.getNamespaceAsString());
-          component.setName(packageUrl.getName());
-          component.setVersion(packageUrl.getVersion());
-          component.setPurl(packageUrl.toString());
-          component.setBomRef(packageUrl.toString());
+          Component component = buildComponent(packageUrl);
 
           for (ComponentReportVulnerability componentVulnerability : componentVulnerabilities) {
             Vulnerability vulnerability = new Vulnerability();
             vulnerability.setBomRef(component.getBomRef());
             vulnerability.setId(componentVulnerability.getId());
 
-            Source source = new Source();
-            source.setName("OSS Index");
-            source.setUrl(componentVulnerability.getReference().toString());
-            vulnerability.setSource(source);
+            addSource(componentVulnerability, vulnerability);
 
-            if (StringUtils.isNotBlank(componentVulnerability.getCve())) {
-              Reference reference = new Reference();
-              reference.setId(componentVulnerability.getCve());
-              vulnerability.setReferences(Collections.singletonList(reference));
-            }
+            addReferences(componentVulnerability, vulnerability);
 
-            Rating rating = new Rating();
-            rating.setScore(Double.valueOf(componentVulnerability.getCvssScore()));
-            rating.setSeverity(Severity.fromString(
-                VulnerabilityUtils.getAssessment(componentVulnerability.getCvssScore()).toLowerCase(Locale.ROOT)));
-            rating.setVector(Objects.toString(componentVulnerability.getCvssVector(), "Unspecified"));
-            vulnerability.addRating(rating);
+            addRating(componentVulnerability, vulnerability);
 
             if (NumberUtils.isDigits(componentVulnerability.getCwe())) {
               vulnerability.addCwe(Integer.parseInt(componentVulnerability.getCwe()));
@@ -126,26 +116,9 @@ public class CycloneDxResponseHandler
 
             vulnerability.setDescription(componentVulnerability.getDescription());
 
-            Tool tool = new Tool();
-            tool.setVendor("Sonatype");
-            tool.setName("Scan Gradle Plugin (aka Sherlock Trunks)");
-            tool.setVersion(PluginVersionUtils.getPluginVersion());
-            vulnerability.setTools(Collections.singletonList(tool));
+            addToolDetails(vulnerability);
 
-            if (componentVulnerability.getVersionRanges() != null
-                && !componentVulnerability.getVersionRanges().isEmpty()) {
-              List<Version> versions = componentVulnerability.getVersionRanges().stream().map(range -> {
-                Version version = new Version();
-                version.setRange(range);
-                version.setStatus(Status.AFFECTED);
-                return version;
-              }).collect(Collectors.toList());
-
-              Affect affect = new Affect();
-              affect.setRef(component.getBomRef());
-              affect.setVersions(versions);
-              vulnerability.setAffects(Collections.singletonList(affect));
-            }
+            addAffectedVersionRanges(component, componentVulnerability, vulnerability);
 
             vulnerabilities.add(vulnerability);
           }
@@ -159,9 +132,97 @@ public class CycloneDxResponseHandler
       bom.setVulnerabilities(vulnerabilities);
     }
 
-    BomJsonGenerator generator = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_14, bom);
-    log.info(generator.toJsonString());
+    generateFile(bom);
 
     return !vulnerabilities.isEmpty();
+  }
+
+  private Component buildComponent(PackageUrl packageUrl) {
+    Component component = new Component();
+    component.setType(Component.Type.LIBRARY);
+    component.setGroup(packageUrl.getNamespaceAsString());
+    component.setName(packageUrl.getName());
+    component.setVersion(packageUrl.getVersion());
+    component.setPurl(packageUrl.toString());
+    component.setBomRef(packageUrl.toString());
+    return component;
+  }
+
+  private void addSource(ComponentReportVulnerability componentVulnerability, Vulnerability vulnerability) {
+    Source source = new Source();
+    source.setName("OSS Index");
+    source.setUrl(componentVulnerability.getReference().toString());
+    vulnerability.setSource(source);
+  }
+
+  private void addReferences(ComponentReportVulnerability componentVulnerability, Vulnerability vulnerability) {
+    List<Reference> references = new ArrayList<>();
+
+    if (StringUtils.isNotBlank(componentVulnerability.getCve())) {
+      Reference reference = new Reference();
+      reference.setId(componentVulnerability.getCve());
+      references.add(reference);
+    }
+
+    componentVulnerability.getExternalReferences().forEach(externalReference -> {
+      Reference reference = new Reference();
+      Source externalSource = new Source();
+      externalSource.setUrl(externalReference.toString());
+      reference.setSource(externalSource);
+      references.add(reference);
+    });
+
+    vulnerability.setReferences(references);
+  }
+
+  private void addRating(ComponentReportVulnerability componentVulnerability, Vulnerability vulnerability) {
+    Rating rating = new Rating();
+    rating.setScore(Double.valueOf(componentVulnerability.getCvssScore()));
+    rating.setSeverity(Severity
+        .fromString(VulnerabilityUtils.getAssessment(componentVulnerability.getCvssScore()).toLowerCase(Locale.ROOT)));
+    rating.setVector(Objects.toString(componentVulnerability.getCvssVector(), "Unspecified"));
+    vulnerability.addRating(rating);
+  }
+
+  private void addToolDetails(Vulnerability vulnerability) {
+    Tool tool = new Tool();
+    tool.setVendor("Sonatype");
+    tool.setName("Scan Gradle Plugin (aka Sherlock Trunks)");
+    tool.setVersion(PluginVersionUtils.getPluginVersion());
+    vulnerability.setTools(Collections.singletonList(tool));
+  }
+
+  private void addAffectedVersionRanges(
+      Component component,
+      ComponentReportVulnerability componentVulnerability,
+      Vulnerability vulnerability)
+  {
+    if (componentVulnerability.getVersionRanges() != null
+        && !componentVulnerability.getVersionRanges().isEmpty()) {
+      List<Version> versions = componentVulnerability.getVersionRanges().stream().map(range -> {
+        Version version = new Version();
+        version.setRange(range);
+        version.setStatus(Status.AFFECTED);
+        return version;
+      }).collect(Collectors.toList());
+
+      Affect affect = new Affect();
+      affect.setRef(component.getBomRef());
+      affect.setVersions(versions);
+      vulnerability.setAffects(Collections.singletonList(affect));
+    }
+  }
+
+  private void generateFile(Bom bom) {
+    BomJsonGenerator generator = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_14, bom);
+
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(new File(FILE_NAME_OUTPUT)))) {
+      writer.write(generator.toJsonString());
+      writer.flush();
+      log.info("CycloneDX SBOM file: {}", FILE_NAME_OUTPUT);
+    }
+    catch (IOException e) {
+      throw new UncheckedIOException("Error generating the CycloneDX SBOM file", e);
+    }
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
@@ -52,6 +52,7 @@ import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability.Rating.Sever
 import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability.Source;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.gradle.api.Project;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.artifacts.ResolvedDependency;
 
@@ -62,8 +63,11 @@ public class CycloneDxResponseHandler
 
   private final OssIndexPluginExtension extension;
 
-  public CycloneDxResponseHandler(OssIndexPluginExtension extension) {
+  private final Project project;
+
+  public CycloneDxResponseHandler(OssIndexPluginExtension extension, Project project) {
     this.extension = extension;
+    this.project = project;
   }
 
   @Override
@@ -151,6 +155,13 @@ public class CycloneDxResponseHandler
     Metadata metadata = new Metadata();
     metadata.addTool(tool);
     metadata.setTimestamp(new Date());
+
+    Component component = new Component();
+    component.setGroup(Objects.toString(project.getGroup()));
+    component.setName(project.getName());
+    component.setVersion(Objects.toString(project.getVersion()));
+    component.setType(extension.getCycloneDxComponentType());
+    metadata.setComponent(component);
 
     bom.setMetadata(metadata);
     return bom;

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
@@ -58,7 +58,7 @@ import org.gradle.api.artifacts.ResolvedDependency;
 public class CycloneDxResponseHandler
     implements OssIndexResponseHandler
 {
-  public static final String FILE_NAME_OUTPUT = "oss-index-cyclonedx.json";
+  public static final String FILE_NAME_OUTPUT = "oss-index-cyclonedx-bom.json";
 
   private final OssIndexPluginExtension extension;
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -106,10 +106,7 @@ public class OssIndexAuditTask
           new VulnerabilityExclusionFilter(vulnerabilityIdsToExclude, coordinatesToExclude);
       vulnerabilityExclusionFilter.apply(response);
 
-      OssIndexResponseHandler responseHandler = /*extension.isDependencyGraph()
-              ? new DependencyGraphResponseHandler(extension)
-              : new DefaultResponseHandler(extension);*/
-          new CycloneDxResponseHandler(extension);
+      OssIndexResponseHandler responseHandler = buildResponseHandler();
       hasVulnerabilities = responseHandler.handleOssIndexResponse(dependencies, dependenciesMap, response);
     }
     catch (TransportException e) {
@@ -202,6 +199,18 @@ public class OssIndexAuditTask
         .build();
   }
 
+  @VisibleForTesting
+  OssIndexResponseHandler buildResponseHandler() {
+    switch (extension.getOutputFormat()) {
+      case DEPENDENCY_GRAPH:
+        return new DependencyGraphResponseHandler(extension);
+      case JSON_CYCLONE_DX_14:
+        return new CycloneDxResponseHandler(extension);
+      default:
+        return new DefaultResponseHandler(extension);
+    }
+  }
+
   @Input
   public String getUsername() {
     return extension.getUsername();
@@ -238,11 +247,6 @@ public class OssIndexAuditTask
   }
 
   @Input
-  public boolean isDependencyGraph() {
-    return extension.isDependencyGraph();
-  }
-
-  @Input
   public boolean isShowAll() {
     return extension.isShowAll();
   }
@@ -262,5 +266,11 @@ public class OssIndexAuditTask
   @Optional
   public Set<String> getModulesExcluded() {
     return extension.getModulesExcluded();
+  }
+
+  @Input
+  @Optional
+  public OutputFormat getOutputFormat() {
+    return extension.getOutputFormat();
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -106,9 +106,10 @@ public class OssIndexAuditTask
           new VulnerabilityExclusionFilter(vulnerabilityIdsToExclude, coordinatesToExclude);
       vulnerabilityExclusionFilter.apply(response);
 
-      OssIndexResponseHandler responseHandler = extension.isDependencyGraph()
+      OssIndexResponseHandler responseHandler = /*extension.isDependencyGraph()
               ? new DependencyGraphResponseHandler(extension)
-              : new DefaultResponseHandler(extension);
+              : new DefaultResponseHandler(extension);*/
+          new CycloneDxResponseHandler(extension);
       hasVulnerabilities = responseHandler.handleOssIndexResponse(dependencies, dependenciesMap, response);
     }
     catch (TransportException e) {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.gradle.api.tasks.Optional;
 import org.sonatype.goodies.packageurl.PackageUrl;
 import org.sonatype.goodies.packageurl.PackageUrlBuilder;
 import org.sonatype.gradle.plugins.scan.common.DependenciesFinder;
@@ -44,11 +43,13 @@ import org.sonatype.ossindex.service.client.transport.Transport.TransportExcepti
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Lists;
+import nexus.shadow.org.cyclonedx.model.Component;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -204,8 +205,8 @@ public class OssIndexAuditTask
     switch (extension.getOutputFormat()) {
       case DEPENDENCY_GRAPH:
         return new DependencyGraphResponseHandler(extension);
-      case JSON_CYCLONE_DX_14:
-        return new CycloneDxResponseHandler(extension);
+      case JSON_CYCLONE_DX_1_4:
+        return new CycloneDxResponseHandler(extension, getProject());
       default:
         return new DefaultResponseHandler(extension);
     }
@@ -272,5 +273,11 @@ public class OssIndexAuditTask
   @Optional
   public OutputFormat getOutputFormat() {
     return extension.getOutputFormat();
+  }
+
+  @Input
+  @Optional
+  public Component.Type getCycloneDxComponentType() {
+    return extension.getCycloneDxComponentType();
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -22,6 +22,7 @@ import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
 
 import groovy.lang.Closure;
+import nexus.shadow.org.cyclonedx.model.Component;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;
 
@@ -66,6 +67,8 @@ public class OssIndexPluginExtension
 
   private OutputFormat outputFormat;
 
+  private Component.Type cycloneDxComponentType;
+
   public OssIndexPluginExtension(Project project) {
     username = "";
     password = "";
@@ -80,6 +83,7 @@ public class OssIndexPluginExtension
     excludeVulnerabilityIds = new HashSet<>();
     excludeCoordinates = new HashSet<>();
     outputFormat = OutputFormat.DEFAULT;
+    cycloneDxComponentType = Component.Type.LIBRARY;
   }
 
   public String getUsername() {
@@ -225,5 +229,13 @@ public class OssIndexPluginExtension
 
   public void setOutputFormat(OutputFormat outputFormat) {
     this.outputFormat = outputFormat;
+  }
+
+  public Component.Type getCycloneDxComponentType() {
+    return cycloneDxComponentType;
+  }
+
+  public void setCycloneDxComponentType(Component.Type cycloneDxComponentType) {
+    this.cycloneDxComponentType = cycloneDxComponentType;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -54,8 +54,6 @@ public class OssIndexPluginExtension
 
   private boolean colorEnabled;
 
-  private boolean dependencyGraph;
-
   private ProxyConfiguration proxyConfiguration;
 
   private boolean showAll;
@@ -66,6 +64,8 @@ public class OssIndexPluginExtension
 
   private Set<String> excludeCoordinates;
 
+  private OutputFormat outputFormat;
+
   public OssIndexPluginExtension(Project project) {
     username = "";
     password = "";
@@ -75,11 +75,11 @@ public class OssIndexPluginExtension
     simulationEnabled = false;
     simulatedVulnerabilityFound = false;
     colorEnabled = true;
-    dependencyGraph = false;
     showAll = false;
     printBanner = true;
     excludeVulnerabilityIds = new HashSet<>();
     excludeCoordinates = new HashSet<>();
+    outputFormat = OutputFormat.DEFAULT;
   }
 
   public String getUsername() {
@@ -169,15 +169,6 @@ public class OssIndexPluginExtension
   public void setColorEnabled(boolean colorEnabled) {
     this.colorEnabled = colorEnabled;
   }
-
-  public boolean isDependencyGraph() {
-    return dependencyGraph;
-  }
-
-  public void setDependencyGraph(boolean dependencyGraph) {
-    this.dependencyGraph = dependencyGraph;
-  }
-
   public ProxyConfiguration getProxyConfiguration() {
     return proxyConfiguration;
   }
@@ -226,5 +217,13 @@ public class OssIndexPluginExtension
 
   public void setExcludeCoordinates(Set<String> excludeCoordinates) {
     this.excludeCoordinates = excludeCoordinates;
+  }
+
+  public OutputFormat getOutputFormat() {
+    return outputFormat;
+  }
+
+  public void setOutputFormat(OutputFormat outputFormat) {
+    this.outputFormat = outputFormat;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OutputFormat.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OutputFormat.java
@@ -19,5 +19,5 @@ public enum OutputFormat
 {
   DEFAULT,
   DEPENDENCY_GRAPH,
-  JSON_CYCLONE_DX_14
+  JSON_CYCLONE_DX_1_4
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OutputFormat.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OutputFormat.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.ossindex;
+
+public enum OutputFormat
+{
+  DEFAULT,
+  DEPENDENCY_GRAPH,
+  JSON_CYCLONE_DX_14
+}

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -22,9 +22,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.sonatype.insight.scan.module.model.Artifact;
-import com.sonatype.insight.scan.module.model.Dependency;
-import com.sonatype.insight.scan.module.model.Module;
+import hidden.com.sonatype.insight.scan.module.model.Artifact;
+import hidden.com.sonatype.insight.scan.module.model.Dependency;
+import hidden.com.sonatype.insight.scan.module.model.Module;
 
 import com.google.common.collect.Sets;
 import org.gradle.api.Project;

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
@@ -22,8 +22,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 
-import com.sonatype.insight.scan.module.model.Module;
-import com.sonatype.insight.scan.module.model.io.ModuleIoManager;
+import hidden.com.sonatype.insight.scan.module.model.Module;
+import hidden.com.sonatype.insight.scan.module.model.io.ModuleIoManager;
 
 import org.sonatype.gradle.plugins.scan.common.DependenciesFinder;
 

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandlerTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandlerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sonatype.gradle.plugins.scan.ossindex;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+
+import org.sonatype.goodies.packageurl.PackageUrl;
+import org.sonatype.goodies.packageurl.PackageUrlBuilder;
+import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
+import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerability;
+
+import nexus.shadow.org.cyclonedx.exception.ParseException;
+import nexus.shadow.org.cyclonedx.model.Bom;
+import nexus.shadow.org.cyclonedx.model.Component;
+import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability;
+import nexus.shadow.org.cyclonedx.parsers.JsonParser;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.sonatype.gradle.plugins.scan.ossindex.CycloneDxResponseHandler.FILE_NAME_OUTPUT;
+
+public class CycloneDxResponseHandlerTest
+{
+  private OssIndexPluginExtension extension;
+
+  private CycloneDxResponseHandler handler;
+
+  @Before
+  public void setup() {
+    extension = new OssIndexPluginExtension(null);
+    extension.setOutputFormat(OutputFormat.JSON_CYCLONE_DX_14);
+    handler = new CycloneDxResponseHandler(extension);
+  }
+
+  @After
+  public void tearDown() {
+    new File(FILE_NAME_OUTPUT).delete();
+  }
+
+  @Test
+  public void testHandleOssIndexResponse_noComponents() {
+    handler.handleOssIndexResponse(Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap());
+
+    File file = new File(FILE_NAME_OUTPUT);
+    assertThat(file.exists()).isFalse();
+  }
+
+  @Test
+  public void testHandleOssIndexResponse_nonVulnerableComponentNoShowAll() {
+    ResolvedDependency resolvedDependency = mock(ResolvedDependency.class);
+    PackageUrl packageUrl = new PackageUrlBuilder().type("maven").namespace("g").name("a").version("v").build();
+    ComponentReport componentReport = new ComponentReport();
+
+    Map<ResolvedDependency, PackageUrl> dependenciesMap = Collections.singletonMap(resolvedDependency, packageUrl);
+    Map<PackageUrl, ComponentReport> response = Collections.singletonMap(packageUrl, componentReport);
+
+    handler.handleOssIndexResponse(Collections.emptySet(), dependenciesMap, response);
+
+    File file = new File(FILE_NAME_OUTPUT);
+    assertThat(file.exists()).isFalse();
+  }
+
+  @Test
+  public void testHandleOssIndexResponse_nonVulnerableComponentShowAll() throws ParseException {
+    extension.setShowAll(true);
+
+    ResolvedDependency resolvedDependency = mock(ResolvedDependency.class);
+    PackageUrl packageUrl = new PackageUrlBuilder().type("maven").namespace("g").name("a").version("v").build();
+    ComponentReport componentReport = new ComponentReport();
+
+    Map<ResolvedDependency, PackageUrl> dependenciesMap = Collections.singletonMap(resolvedDependency, packageUrl);
+    Map<PackageUrl, ComponentReport> response = Collections.singletonMap(packageUrl, componentReport);
+
+    handler.handleOssIndexResponse(Collections.emptySet(), dependenciesMap, response);
+
+    File file = new File(FILE_NAME_OUTPUT);
+    assertThat(file.exists()).isTrue();
+
+    JsonParser jsonParser = new JsonParser();
+    Bom bom = jsonParser.parse(file);
+    assertThat(bom).isNotNull();
+    assertThat(bom.getVulnerabilities()).isNullOrEmpty();
+
+    assertComponent(packageUrl, bom);
+  }
+
+  @Test
+  public void testHandleOssIndexResponse_vulnerableComponent() throws ParseException {
+    ResolvedDependency resolvedDependency = mock(ResolvedDependency.class);
+    PackageUrl packageUrl = new PackageUrlBuilder().type("maven").namespace("g").name("a").version("v").build();
+
+    ComponentReport componentReport = new ComponentReport();
+    componentReport.setCoordinates(packageUrl);
+
+    ComponentReportVulnerability vulnerability = new ComponentReportVulnerability();
+    vulnerability.setId("TEST-123");
+    vulnerability.setReference(URI.create("https://test.com/TEST-123"));
+    vulnerability.setCvssScore(10.0F);
+    componentReport.setVulnerabilities(Collections.singletonList(vulnerability));
+
+    Map<ResolvedDependency, PackageUrl> dependenciesMap = Collections.singletonMap(resolvedDependency, packageUrl);
+    Map<PackageUrl, ComponentReport> response = Collections.singletonMap(packageUrl, componentReport);
+
+    handler.handleOssIndexResponse(Collections.emptySet(), dependenciesMap, response);
+
+    File file = new File(FILE_NAME_OUTPUT);
+    assertThat(file.exists()).isTrue();
+
+    JsonParser jsonParser = new JsonParser();
+    Bom bom = jsonParser.parse(file);
+    assertThat(bom).isNotNull();
+
+    assertComponent(packageUrl, bom);
+
+    assertThat(bom.getVulnerabilities()).hasSize(1);
+    Vulnerability resultVulnerability = bom.getVulnerabilities().get(0);
+    assertThat(resultVulnerability.getBomRef()).isEqualTo(packageUrl.toString());
+    assertThat(resultVulnerability.getId()).isEqualTo("TEST-123");
+    assertThat(resultVulnerability.getSource()).isNotNull();
+    assertThat(resultVulnerability.getSource().getName()).isEqualTo("OSS Index");
+    assertThat(resultVulnerability.getSource().getUrl()).isEqualTo("https://test.com/TEST-123");
+    assertThat(resultVulnerability.getRatings()).hasSize(1);
+    assertThat(resultVulnerability.getRatings().get(0).getScore()).isEqualTo(10.0);
+  }
+
+  private void assertComponent(PackageUrl packageUrl, Bom bom) {
+    Component component = new Component();
+    component.setType(Component.Type.LIBRARY);
+    component.setGroup(packageUrl.getNamespaceAsString());
+    component.setName(packageUrl.getName());
+    component.setVersion(packageUrl.getVersion());
+    component.setPurl(packageUrl.toString());
+    component.setBomRef(packageUrl.toString());
+
+    assertThat(bom.getComponents()).containsExactly(component);
+  }
+}

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandlerTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandlerTest.java
@@ -42,26 +42,40 @@ import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability.Affect;
 import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability.Rating;
 import nexus.shadow.org.cyclonedx.model.vulnerability.Vulnerability.Rating.Severity;
 import nexus.shadow.org.cyclonedx.parsers.JsonParser;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.sonatype.gradle.plugins.scan.ossindex.CycloneDxResponseHandler.FILE_NAME_OUTPUT;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CycloneDxResponseHandlerTest
 {
   private OssIndexPluginExtension extension;
 
   private CycloneDxResponseHandler handler;
 
+  @Mock
+  private Project project;
+
   @Before
   public void setup() {
     extension = new OssIndexPluginExtension(null);
-    extension.setOutputFormat(OutputFormat.JSON_CYCLONE_DX_14);
-    handler = new CycloneDxResponseHandler(extension);
+    extension.setOutputFormat(OutputFormat.JSON_CYCLONE_DX_1_4);
+
+    when(project.getGroup()).thenReturn("test-group");
+    when(project.getName()).thenReturn("some-name");
+    when(project.getVersion()).thenReturn("0.0.1");
+
+    handler = new CycloneDxResponseHandler(extension, project);
   }
 
   @After
@@ -118,6 +132,12 @@ public class CycloneDxResponseHandlerTest
     Metadata metadata = bom.getMetadata();
     assertThat(metadata).isNotNull();
     assertThat(metadata.getTimestamp()).isNotNull();
+
+    Component component = bom.getMetadata().getComponent();
+    assertThat(component).isNotNull();
+    assertThat(component.getGroup()).isEqualTo(project.getGroup());
+    assertThat(component.getName()).isEqualTo(project.getName());
+    assertThat(component.getVersion()).isEqualTo(project.getVersion());
 
     assertThat(metadata.getTools()).hasSize(1);
     Tool tool = metadata.getTools().get(0);

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
@@ -186,6 +186,27 @@ public class OssIndexAuditTaskTest
         subChildDependency);
   }
 
+  @Test
+  public void testBuildResponseHandler_defaultResponseHandler() {
+    OssIndexAuditTask taskSpy =
+        buildAuditTaskSpy(true, (project, extension) -> extension.setOutputFormat(OutputFormat.DEFAULT));
+    assertThat(taskSpy.buildResponseHandler()).isInstanceOf(DefaultResponseHandler.class);
+  }
+
+  @Test
+  public void testBuildResponseHandler_dependencyGraphResponseHandler() {
+    OssIndexAuditTask taskSpy =
+        buildAuditTaskSpy(true, (project, extension) -> extension.setOutputFormat(OutputFormat.DEPENDENCY_GRAPH));
+    assertThat(taskSpy.buildResponseHandler()).isInstanceOf(DependencyGraphResponseHandler.class);
+  }
+
+  @Test
+  public void testBuildResponseHandler_cycloneDxResponseHandler() {
+    OssIndexAuditTask taskSpy =
+        buildAuditTaskSpy(true, (project, extension) -> extension.setOutputFormat(OutputFormat.JSON_CYCLONE_DX_14));
+    assertThat(taskSpy.buildResponseHandler()).isInstanceOf(CycloneDxResponseHandler.class);
+  }
+
   private OssIndexAuditTask buildAuditTaskSpy(boolean isSimulated, BiConsumer<Project, OssIndexPluginExtension> extensionContributor) {
     Project project = ProjectBuilder.builder().build();
     project.getPluginManager().apply("java");

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
@@ -203,7 +203,7 @@ public class OssIndexAuditTaskTest
   @Test
   public void testBuildResponseHandler_cycloneDxResponseHandler() {
     OssIndexAuditTask taskSpy =
-        buildAuditTaskSpy(true, (project, extension) -> extension.setOutputFormat(OutputFormat.JSON_CYCLONE_DX_14));
+        buildAuditTaskSpy(true, (project, extension) -> extension.setOutputFormat(OutputFormat.JSON_CYCLONE_DX_1_4));
     assertThat(taskSpy.buildResponseHandler()).isInstanceOf(CycloneDxResponseHandler.class);
   }
 


### PR DESCRIPTION
Allows to generate a JSON file using the CycloneDX 1.4 JSON format with both components and vulnerabilities on the SBOM.

In this first step, no dependency relationship is made so we can deliver this feature a bit faster (the issue requesting this has been around for quite a while) and hopefully such relationship can be developed later.

An example:
```json
{
  "bomFormat" : "CycloneDX",
  "specVersion" : "1.4",
  "serialNumber" : "urn:uuid:87db34d1-5a5c-44ff-b1d8-061fd429d40c",
  "version" : 1,
  "metadata" : {
    "timestamp" : "2022-06-10T00:16:48Z",
    "tools" : [
      {
        "vendor" : "Sonatype",
        "name" : "Scan Gradle Plugin (aka Sherlock Trunks)",
        "version" : "2.4.0-SNAPSHOT"
      }
    ],
    "component" : {
      "group" : "org.sonatype",
      "name" : "test-artifact",
      "version" : "0.0.1",
      "type" : "library"
    }
  },
  "components" : [
    {
      "group" : "com.squareup.retrofit2",
      "name" : "retrofit",
      "version" : "2.9.0",
      "purl" : "pkg:maven/com.squareup.retrofit2/retrofit@2.9.0",
      "type" : "library",
      "bom-ref" : "pkg:maven/com.squareup.retrofit2/retrofit@2.9.0"
    },
    {
      "group" : "com.squareup.okhttp3",
      "name" : "okhttp",
      "version" : "3.14.9",
      "purl" : "pkg:maven/com.squareup.okhttp3/okhttp@3.14.9",
      "type" : "library",
      "bom-ref" : "pkg:maven/com.squareup.okhttp3/okhttp@3.14.9"
    },
    {
      "group" : "com.squareup.okio",
      "name" : "okio",
      "version" : "1.17.2",
      "purl" : "pkg:maven/com.squareup.okio/okio@1.17.2",
      "type" : "library",
      "bom-ref" : "pkg:maven/com.squareup.okio/okio@1.17.2"
    }
  ],
  "vulnerabilities" : [
    {
      "id" : "CVE-2021-0341",
      "source" : {
        "name" : "OSS Index",
        "url" : "https://ossindex.sonatype.org/vulnerability/CVE-2021-0341?component-type=maven&component-name=com.squareup.okhttp3%2Fokhttp&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1"
      },
      "ratings" : [
        {
          "score" : 7.5,
          "severity" : "high",
          "vector" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
        }
      ],
      "cwes" : [
        295
      ],
      "description" : "In verifyHostName of OkHostnameVerifier.java, there is a possible way to accept a certificate for the wrong domain due to improperly used crypto. This could lead to remote information disclosure with no additional execution privileges needed. User interaction is not needed for exploitation.Product: AndroidVersions: Android-8.1 Android-9 Android-10 Android-11Android ID: A-171980069",
      "advisories" : [
        {
          "url" : "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-0341"
        },
        {
          "url" : "https://github.com/square/okhttp/pull/6353"
        },
        {
          "url" : "https://source.android.com/security/bulletin/2021-02-01#android-runtime"
        }
      ],
      "tools" : [
        {
          "vendor" : "Sonatype",
          "name" : "OSS Index"
        }
      ],
      "affects" : [
        {
          "ref" : "pkg:maven/com.squareup.okhttp3/okhttp@3.14.9"
        }
      ]
    }
  ]
}
```

It relates to the following issue #s:
* Fixes #94 

cc @bhamail / @DarthHater / @shaikhu
