### PR TITLE
Adding commons-io to shadded nexus-platform-api.

### DIFF
--- a/nexus-platform-api/build.gradle
+++ b/nexus-platform-api/build.gradle
@@ -36,4 +36,5 @@ artifacts {
 
 dependencies {
   implementation "com.sonatype.nexus:nexus-platform-api:$nexusPlatformApiVersion"
+  implementation "commons-io:commons-io:$commonsIoVersion"
 }


### PR DESCRIPTION
Fixes NoClassDefFoundError: nexus/shadow/org//apache/common/io/IOUtils as NpmManifestFileReader.read ( line 21 ).

This pull request makes the following changes:
* added dependency on commons-io in build.gradle of nexus-platform-api

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
