### PR TITLE
Skip unresolvable dependencies

### DIFF
--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -180,7 +180,7 @@ public class DependenciesFinder
       try {
         return function.apply(copyConfiguration.getResolvedConfiguration());
       }
-      catch (Exception lastResortException) {
+      catch (ResolveException lastResortException) {
         copyConfiguration = copyDependencies(project, originalConfiguration, true);
         return function.apply(copyConfiguration.getResolvedConfiguration());
       }
@@ -207,9 +207,9 @@ public class DependenciesFinder
             originalConfiguration.files(dependency);
           }
           catch (Exception e) {
-            log.warn("Unable to process the dependency " + dependency.getGroup() + ":" + dependency.getName() + ":"
-                + dependency.getVersion() + " in project " + project.getName() + " and configuration "
-                + originalConfiguration.getName());
+            log.warn("Unable to process the dependency {}:{}:{} in project {} and configuration {}",
+                dependency.getGroup(), dependency.getName(), dependency.getVersion(), project.getName(),
+                originalConfiguration.getName());
             copyConfiguration.getDependencies().remove(dependency);
           }
         }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -31,7 +31,6 @@ import java.util.stream.Stream;
 import hidden.com.sonatype.insight.scan.module.model.Artifact;
 import hidden.com.sonatype.insight.scan.module.model.Dependency;
 import hidden.com.sonatype.insight.scan.module.model.Module;
-
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -44,12 +43,16 @@ import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME;
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME;
 
 public class DependenciesFinder
 {
+  private final Logger log = LoggerFactory.getLogger(DependenciesFinder.class);
+
   private static final String RELEASE_COMPILE_LEGACY_CONFIGURATION_NAME = "_releaseCompile";
 
   private static final String RELEASE_RUNTIME_APK_LEGACY_CONFIGURATION_NAME = "_releaseApk";
@@ -172,20 +175,48 @@ public class DependenciesFinder
       return function.apply(originalConfiguration.getResolvedConfiguration());
     }
     catch (ResolveException e) {
-      Configuration copyConfiguration = createCopyConfiguration(project);
+      Configuration copyConfiguration = copyDependencies(project, originalConfiguration, false);
 
-      originalConfiguration.getAllDependencies().all(dependency -> {
-        if (dependency instanceof ProjectDependency) {
-          Project dependencyProject = ((ProjectDependency) dependency).getDependencyProject();
-          project.evaluationDependsOn(dependencyProject.getPath());
-        }
-        else {
-          copyConfiguration.getDependencies().add(dependency);
-        }
-      });
-
-      return function.apply(copyConfiguration.getResolvedConfiguration());
+      try {
+        return function.apply(copyConfiguration.getResolvedConfiguration());
+      }
+      catch (Exception lastResortException) {
+        copyConfiguration = copyDependencies(project, originalConfiguration, true);
+        return function.apply(copyConfiguration.getResolvedConfiguration());
+      }
     }
+  }
+
+  private Configuration copyDependencies(
+      Project project,
+      Configuration originalConfiguration,
+      boolean skipUnresolvableDependencies)
+  {
+    Configuration copyConfiguration = createCopyConfiguration(project);
+
+    originalConfiguration.getAllDependencies().all(dependency -> {
+      if (dependency instanceof ProjectDependency) {
+        Project dependencyProject = ((ProjectDependency) dependency).getDependencyProject();
+        project.evaluationDependsOn(dependencyProject.getPath());
+      }
+      else {
+        copyConfiguration.getDependencies().add(dependency);
+
+        if (skipUnresolvableDependencies) {
+          try {
+            originalConfiguration.files(dependency);
+          }
+          catch (Exception e) {
+            log.warn("Unable to process the dependency " + dependency.getGroup() + ":" + dependency.getName() + ":"
+                + dependency.getVersion() + " in project " + project.getName() + " and configuration "
+                + originalConfiguration.getName());
+            copyConfiguration.getDependencies().remove(dependency);
+          }
+        }
+      }
+    });
+
+    return copyConfiguration;
   }
 
   @VisibleForTesting

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -22,13 +22,17 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.collect.Sets;
 import hidden.com.sonatype.insight.scan.module.model.Artifact;
 import hidden.com.sonatype.insight.scan.module.model.Dependency;
 import hidden.com.sonatype.insight.scan.module.model.Module;
-
-import com.google.common.collect.Sets;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.*;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolveException;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
@@ -411,7 +415,7 @@ public class DependenciesFinderTest
   }
 
   @Test
-  public void testGetDependencies_ResolvedArtifacts_WithDoubleError() {
+  public void testGetDependencies_ResolvedArtifacts_Skip_Unresolvable_Dependencies() {
     Project project = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
     DependencyHandler dependencyHandler = project.getDependencies();
     org.gradle.api.artifacts.Dependency testDependency =


### PR DESCRIPTION
When using dependency substitution to replace an external dependency with a local project, as explained in #117, the plugin is unable to resolve such dependency.

When it gets here:
https://github.com/sonatype-nexus-community/scan-gradle-plugin/blob/6de7fa931531dc11a3ea64c9b575604c50e6f008/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java#L178-L184

We get the dependency as an external one instead of an instance of `ProjectDependency` and there doesn't seem to be a way to differenciate that dependency from others.

With this PR the plugin will try once to resolve the failed configuration as usual and if that fails a second attempt will be made but this time skipping and logging the dependencies that cannot be resolved.

```
> Task :nexusIQScan
Unable to process the dependency com.example.libs:samplelib:1.0.0 in project app and configuration releaseCompileClasspath
Unable to process the dependency com.example.libs:samplelib:1.0.0 in project app and configuration releaseRuntimeClasspath
```

Dependencies from the replacing external module would have to be evaluated separately by running the plugin there.

It relates to the following issue #s:
* Fixes #117

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
