### PR TITLE
Allow to set attributes to match a variant after a conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target/
 .classpath
 .project
 .idea
+.DS_Store
 
 # ci config for local ci build
 .circleci/local-config.yml

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ ossIndexAudit {
     modulesIncluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to include for auditing. If not specified all modules are included.
     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing. If not specified no modules are excluded. This value is processed after 'modulesIncluded' if both are specified.
 
-    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
+    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at the section "How to Deal with Multiple Release Variants" below in this doc.
     variantAttributes = ['com.android.build.api.attributes.ProductFlavor:version': 'prod', 'other.attribute': 'other value'] // Optional, use it only when the plugin can't match a variant on its own
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
@@ -133,7 +133,7 @@ ossIndexAudit {
     modulesIncluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to include for auditing. If not specified all modules are included.
     modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing. If not specified no modules are excluded. This value is processed after 'modulesIncluded' if both are specified.
 
-    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
+    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at the section "How to Deal with Multiple Release Variants" below in this doc.
     variantAttributes = mapOf("com.android.build.api.attributes.ProductFlavor:version" to "prod", "other.attribute" to "other value") // Optional, use it only when the plugin can't match a variant on its own
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
@@ -173,7 +173,7 @@ nexusIQScan {
     dirExcludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using '**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar'
     dirIncludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
 
-    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
+    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at the section "How to Deal with Multiple Release Variants" below in this doc.
     variantAttributes = ['com.android.build.api.attributes.ProductFlavor:version': 'prod', 'other.attribute': 'other value'] // Optional, use it only when the plugin can't match a variant on its own
 }
 ```
@@ -193,7 +193,7 @@ nexusIQScan {
     dirExcludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using "**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar"
     dirIncludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
 
-    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
+    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at the section "How to Deal with Multiple Release Variants" below in this doc.
     variantAttributes = mapOf("com.android.build.api.attributes.ProductFlavor:version" to "prod", "other.attribute" to "other value") // Optional, use it only when the plugin can't match a variant on its own
 }
 ```

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Gradle can be used to build projects developed in various programming languages.
 
 ```
 plugins {
-  id 'org.sonatype.gradle.plugins.scan' version '2.5.4' // Update the version as needed
+  id 'org.sonatype.gradle.plugins.scan' version '2.5.5' // Update the version as needed
 }
 ```
 
 - Or `build.gradle.kts`:
 ```
 plugins {
-    id ("org.sonatype.gradle.plugins.scan") version "2.5.4" // Update the version as needed
+    id ("org.sonatype.gradle.plugins.scan") version "2.5.5" // Update the version as needed
 }
 ```
 
@@ -95,6 +95,9 @@ ossIndexAudit {
     }
     modulesIncluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to include for auditing. If not specified all modules are included.
     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing. If not specified no modules are excluded. This value is processed after 'modulesIncluded' if both are specified.
+
+    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
+    variantAttributes = ['com.android.build.api.attributes.ProductFlavor:version': 'prod', 'other.attribute': 'other value'] // Optional, use it only when the plugin can't match a variant on its own
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
     excludeVulnerabilityIds = ['39d74cc8-457a-4e57-89ef-a258420138c5'] // list containing ids of vulnerabilities to be ignored
@@ -129,6 +132,9 @@ ossIndexAudit {
     }
     modulesIncluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to include for auditing. If not specified all modules are included.
     modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing. If not specified no modules are excluded. This value is processed after 'modulesIncluded' if both are specified.
+
+    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
+    variantAttributes = mapOf('com.android.build.api.attributes.ProductFlavor:version' to 'prod', 'other.attribute' to 'other value') // Optional, use it only when the plugin can't match a variant on its own
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
     excludeVulnerabilityIds =
@@ -166,6 +172,9 @@ nexusIQScan {
     modulesExcluded = ['module-1', 'module-2'] // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
     dirExcludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using '**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar'
     dirIncludes = 'some-ant-pattern' // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
+
+    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
+    variantAttributes = ['com.android.build.api.attributes.ProductFlavor:version': 'prod', 'other.attribute': 'other value'] // Optional, use it only when the plugin can't match a variant on its own
 }
 ```
 
@@ -183,6 +192,9 @@ nexusIQScan {
     modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from scanning and evaluation.
     dirExcludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be excluded. For Android projects we suggest using "**/classes.jar,**/annotations.zip,**/lint.jar,**/internal_impl-*.jar"
     dirIncludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
+
+    // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
+    variantAttributes = mapOf('com.android.build.api.attributes.ProductFlavor:version' to 'prod', 'other.attribute' to 'other value') // Optional, use it only when the plugin can't match a variant on its own
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ ossIndexAudit {
     modulesExcluded = listOf("module-1", "module-2") // Optional. For multi-module projects, the names of the sub-modules to exclude from auditing. If not specified no modules are excluded. This value is processed after 'modulesIncluded' if both are specified.
 
     // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
-    variantAttributes = mapOf('com.android.build.api.attributes.ProductFlavor:version' to 'prod', 'other.attribute' to 'other value') // Optional, use it only when the plugin can't match a variant on its own
+    variantAttributes = mapOf("com.android.build.api.attributes.ProductFlavor:version" to "prod", "other.attribute" to "other value") // Optional, use it only when the plugin can't match a variant on its own
 
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
     excludeVulnerabilityIds =
@@ -194,7 +194,7 @@ nexusIQScan {
     dirIncludes = "some-ant-pattern" // Optional. Comma separated ant-like glob patterns to select directories/archives that should be examined
 
     // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
-    variantAttributes = mapOf('com.android.build.api.attributes.ProductFlavor:version' to 'prod', 'other.attribute' to 'other value') // Optional, use it only when the plugin can't match a variant on its own
+    variantAttributes = mapOf("com.android.build.api.attributes.ProductFlavor:version" to "prod", "other.attribute" to "other value") // Optional, use it only when the plugin can't match a variant on its own
 }
 ```
 
@@ -317,6 +317,66 @@ ossIndexAudit {
 ### Multi-module projects
 Just apply the plugin on the root project and all sub-modules will be processed and the output will be a single report
 with all components found in each module. This includes Android projects.
+
+## How to Deal with Multiple Release Variants
+This plugin makes its best effort to find the release (production) configuration and variant to get the dependencies to analyze.
+
+However, a Gradle project can have multiple custom release variants and the plugin might not be able to tell Gradle which one to pick, resulting in an error like this:
+
+```
+> Could not resolve all dependencies for configuration 'sonatypeCopyConfiguration0'.
+   > Could not resolve project :common-lib.
+     Required by:
+         project :app
+      > The consumer was configured to find a runtime of a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release'. However we cannot choose between the following variants of project :baseapp:
+          - ciReleaseRuntimeElements
+          - prodReleaseRuntimeElements
+        All of them match the consumer attributes:
+          - Variant 'ciReleaseRuntimeElements' capability common-lib:1.0.0 declares a runtime of a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release':
+              - Unmatched attributes:
+                  - Provides attribute 'com.android.build.api.attributes.AgpVersionAttr' with value '7.2.2' but the consumer didn't ask for it
+                  - Provides attribute 'com.android.build.api.attributes.ProductFlavor:version' with value 'ci' but the consumer didn't ask for it
+                  - Provides attribute 'com.android.build.gradle.internal.attributes.VariantAttr' with value 'ciRelease' but the consumer didn't ask for it
+                  - Provides a library but the consumer didn't ask for it
+                  - Provides attribute 'org.gradle.jvm.environment' with value 'android' but the consumer didn't ask for it
+          - Variant 'prodReleaseRuntimeElements' capability common-lib:1.0.0 declares a runtime of a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release':
+              - Unmatched attributes:
+                  - Provides attribute 'com.android.build.api.attributes.AgpVersionAttr' with value '7.2.2' but the consumer didn't ask for it
+                  - Provides attribute 'com.android.build.api.attributes.ProductFlavor:version' with value 'prod' but the consumer didn't ask for it
+                  - Provides attribute 'com.android.build.gradle.internal.attributes.VariantAttr' with value 'prodRelease' but the consumer didn't ask for it
+                  - Provides a library but the consumer didn't ask for it
+                  - Provides attribute 'org.gradle.jvm.environment' with value 'android' but the consumer didn't ask for it
+```
+
+From that output we can see the value of the attribute `com.android.build.api.attributes.ProductFlavor:version` can be used to distinguish between the available variants.
+
+Since attribute names and values can be customized on each project, this plugin allows to set the attributes needed to match the right variant using the property `variantAttributes`.
+
+In the example above, the following configuration would allow the plugin to choose the `prodReleaseRuntimeElements` variant:
+
+*Groovy*
+```
+nexusIQScan {
+    variantAttributes = ['com.android.build.api.attributes.ProductFlavor:version': 'prod']
+}
+
+ossIndexAudit {
+    variantAttributes = ['com.android.build.api.attributes.ProductFlavor:version': 'prod']
+}
+```
+
+*Kotlin*
+```
+nexusIQScan {
+    variantAttributes = mapOf("com.android.build.api.attributes.ProductFlavor:version" to "prod")
+}
+
+ossIndexAudit {
+    variantAttributes = mapOf("com.android.build.api.attributes.ProductFlavor:version" to "prod")
+}
+```
+
+See more information about attributes matching for variant selection see https://docs.gradle.org/current/userguide/variant_model.html#sec:variant-select-errors
 
 ## Contributing
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/AndroidArtifactTypeAttributeDisambiguationRule.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/AndroidArtifactTypeAttributeDisambiguationRule.java
@@ -20,7 +20,7 @@ import org.gradle.api.attributes.MultipleCandidatesDetails;
 
 import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.JAR_TYPE;
 
-public class AndroidAttributeDisambiguationRule
+public class AndroidArtifactTypeAttributeDisambiguationRule
     implements AttributeDisambiguationRule<String>
 {
   private static final String AAR_TYPE = "aar";

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -16,7 +16,6 @@
 package org.sonatype.gradle.plugins.scan.common;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -85,10 +84,14 @@ public class DependenciesFinder
 
   private static final String ATTRIBUTES_SUPPORTED_GRADLE_VERSION = "4.0";
 
-  public Set<ResolvedDependency> findResolvedDependencies(Project project, boolean allConfigurations) {
+  public Set<ResolvedDependency> findResolvedDependencies(
+      Project project,
+      boolean allConfigurations,
+      Map<String, String> variantAttributes)
+  {
     return new LinkedHashSet<>(new LinkedHashSet<>(project.getConfigurations()).stream()
         .filter(configuration -> isAcceptableConfiguration(configuration, allConfigurations))
-        .flatMap(configuration -> getDependencies(project, configuration, Collections.emptyMap(),
+        .flatMap(configuration -> getDependencies(project, configuration, variantAttributes,
             resolvedConfiguration -> resolvedConfiguration.getFirstLevelModuleDependencies().stream()))
         .collect(collectResolvedDependencies()).values());
   }
@@ -116,8 +119,8 @@ public class DependenciesFinder
           module.addConsumedArtifact(artifact);
         });
 
-        findResolvedDependencies(project, allConfigurations).forEach(resolvedDependency ->
-          module.addDependency(processDependency(resolvedDependency, true, new HashSet<>()))
+        findResolvedDependencies(project, allConfigurations, variantAttributes).forEach(
+            resolvedDependency -> module.addDependency(processDependency(resolvedDependency, true, new HashSet<>()))
         );
 
         modules.add(module);

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -16,11 +16,13 @@
 package org.sonatype.gradle.plugins.scan.common;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -86,27 +88,24 @@ public class DependenciesFinder
   public Set<ResolvedDependency> findResolvedDependencies(Project project, boolean allConfigurations) {
     return new LinkedHashSet<>(new LinkedHashSet<>(project.getConfigurations()).stream()
         .filter(configuration -> isAcceptableConfiguration(configuration, allConfigurations))
-        .flatMap(configuration -> getDependencies(project, configuration,
+        .flatMap(configuration -> getDependencies(project, configuration, Collections.emptyMap(),
             resolvedConfiguration -> resolvedConfiguration.getFirstLevelModuleDependencies().stream()))
         .collect(collectResolvedDependencies()).values());
   }
 
-  public Set<ResolvedArtifact> findResolvedArtifacts(Project project, boolean allConfigurations) {
-    return new LinkedHashSet<>(project.getConfigurations()).stream()
-        .filter(configuration -> isAcceptableConfiguration(configuration, allConfigurations))
-        .flatMap(configuration -> getDependencies(project, configuration,
-            resolvedConfiguration -> resolvedConfiguration.getResolvedArtifacts().stream()))
-        .collect(Collectors.toSet());
-  }
-
-  public List<Module> findModules(Project rootProject, boolean allConfigurations, Set<String> modulesExcluded) {
+  public List<Module> findModules(
+      Project rootProject,
+      boolean allConfigurations,
+      Set<String> modulesExcluded,
+      Map<String, String> variantAttributes)
+  {
     List<Module> modules = new ArrayList<>();
 
     rootProject.allprojects(project -> {
       if (!modulesExcluded.contains(project.getName())) {
         Module module = buildModule(project);
 
-        findResolvedArtifacts(project, allConfigurations).forEach(resolvedArtifact -> {
+        findResolvedArtifacts(project, allConfigurations, variantAttributes).forEach(resolvedArtifact -> {
           ModuleVersionIdentifier artifactId = resolvedArtifact.getModuleVersion().getId();
 
           Artifact artifact = new Artifact()
@@ -126,6 +125,19 @@ public class DependenciesFinder
     });
 
     return modules;
+  }
+
+  @VisibleForTesting
+  Set<ResolvedArtifact> findResolvedArtifacts(
+      Project project,
+      boolean allConfigurations,
+      Map<String, String> variantAttributes)
+  {
+    return new LinkedHashSet<>(project.getConfigurations()).stream()
+        .filter(configuration -> isAcceptableConfiguration(configuration, allConfigurations))
+        .flatMap(configuration -> getDependencies(project, configuration, variantAttributes,
+            resolvedConfiguration -> resolvedConfiguration.getResolvedArtifacts().stream()))
+        .collect(Collectors.toSet());
   }
 
   @VisibleForTesting
@@ -158,7 +170,7 @@ public class DependenciesFinder
   }
 
   @VisibleForTesting
-  Configuration createCopyConfiguration(Project project) {
+  Configuration createCopyConfiguration(Project project, Map<String, String> variantAttributes) {
     String configurationName = COPY_CONFIGURATION_NAME;
     for (int i = 0; project.getConfigurations().findByName(configurationName) != null; i++) {
       configurationName += i;
@@ -171,12 +183,16 @@ public class DependenciesFinder
       if (isAndroidProject) {
         AttributeMatchingStrategy<String> artifactTypeMatchingStrategy =
             project.getDependencies().getAttributesSchema().attribute(Attribute.of("artifactType", String.class));
-        artifactTypeMatchingStrategy.getDisambiguationRules().add(AndroidAttributeDisambiguationRule.class);
+        artifactTypeMatchingStrategy.getDisambiguationRules().add(AndroidArtifactTypeAttributeDisambiguationRule.class);
       }
 
       copyConfiguration.attributes(attributeContainer -> {
         ObjectFactory factory = project.getObjects();
         attributeContainer.attribute(Usage.USAGE_ATTRIBUTE, factory.named(Usage.class, Usage.JAVA_RUNTIME));
+
+        variantAttributes.forEach((attributeName, value) -> {
+          attributeContainer.attribute(Attribute.of(attributeName, String.class), value);
+        });
 
         if (isAndroidProject) {
           addReleaseBuildTypeAttribute(project, attributeContainer);
@@ -233,19 +249,20 @@ public class DependenciesFinder
   <T> Stream<T> getDependencies(
       Project project,
       Configuration originalConfiguration,
+      Map<String, String> variantAttributes,
       Function<ResolvedConfiguration, Stream<T>> function)
   {
     try {
       return function.apply(originalConfiguration.getResolvedConfiguration());
     }
     catch (ResolveException e) {
-      Configuration copyConfiguration = copyDependencies(project, originalConfiguration, false);
+      Configuration copyConfiguration = copyDependencies(project, originalConfiguration, false, variantAttributes);
 
       try {
         return function.apply(copyConfiguration.getResolvedConfiguration());
       }
       catch (ResolveException lastResortException) {
-        copyConfiguration = copyDependencies(project, originalConfiguration, true);
+        copyConfiguration = copyDependencies(project, originalConfiguration, true, variantAttributes);
         return function.apply(copyConfiguration.getResolvedConfiguration());
       }
     }
@@ -254,9 +271,10 @@ public class DependenciesFinder
   private Configuration copyDependencies(
       Project project,
       Configuration originalConfiguration,
-      boolean skipUnresolvableDependencies)
+      boolean skipUnresolvableDependencies,
+      Map<String, String> variantAttributes)
   {
-    Configuration copyConfiguration = createCopyConfiguration(project);
+    Configuration copyConfiguration = createCopyConfiguration(project, variantAttributes);
 
     originalConfiguration.getAllDependencies().all(dependency -> {
       copyConfiguration.getDependencies().add(dependency);

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
@@ -59,8 +59,8 @@ public class NexusIqIndexTask
   @TaskAction
   public void saveModule() {
     try {
-      List<Module> modules =
-          dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(), extension.getModulesExcluded());
+      List<Module> modules = dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(),
+          extension.getModulesExcluded(), extension.getVariantAttributes());
       List<File> files = new ArrayList<>(modules.size());
 
       for (Module module : modules) {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqPluginIndexExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqPluginIndexExtension.java
@@ -16,6 +16,7 @@
 package org.sonatype.gradle.plugins.scan.nexus.iq.index;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 import org.gradle.api.Project;
@@ -26,8 +27,11 @@ public class NexusIqPluginIndexExtension
 
   private Set<String> modulesExcluded;
 
+  private Map<String, String> variantAttributes;
+
   public NexusIqPluginIndexExtension(Project project) {
     modulesExcluded = Collections.emptySet();
+    variantAttributes = Collections.emptyMap();
   }
 
   public boolean isAllConfigurations() {
@@ -44,5 +48,13 @@ public class NexusIqPluginIndexExtension
 
   public void setModulesExcluded(Set<String> modulesExcluded) {
     this.modulesExcluded = modulesExcluded;
+  }
+
+  public Map<String, String> getVariantAttributes() {
+    return variantAttributes;
+  }
+
+  public void setVariantAttributes(Map<String, String> variantAttributes) {
+    this.variantAttributes = variantAttributes;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
@@ -16,6 +16,7 @@
 package org.sonatype.gradle.plugins.scan.nexus.iq.scan;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 import com.sonatype.clm.dto.model.policy.Stage;
@@ -55,6 +56,8 @@ public class NexusIqPluginScanExtension
 
   private String dirExcludes;
 
+  private Map<String, String> variantAttributes;
+
   public NexusIqPluginScanExtension(Project project) {
     stage = Stage.ID_BUILD;
     organizationId = "";
@@ -64,6 +67,7 @@ public class NexusIqPluginScanExtension
     modulesExcluded = Collections.emptySet();
     dirIncludes = "";
     dirExcludes = "";
+    variantAttributes = Collections.emptyMap();
   }
 
   public String getUsername() {
@@ -177,5 +181,13 @@ public class NexusIqPluginScanExtension
 
   public void setDirExcludes(String dirExcludes) {
     this.dirExcludes = dirExcludes;
+  }
+
+  public Map<String, String> getVariantAttributes() {
+    return variantAttributes;
+  }
+
+  public void setVariantAttributes(Map<String, String> variantAttributes) {
+    this.variantAttributes = variantAttributes;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
@@ -82,7 +82,8 @@ public class NexusIqScanTask
               Collections.singletonList(new Action(extension.getSimulatedPolicyActionId()))));
         }
 
-        dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(), extension.getModulesExcluded());
+        dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(), extension.getModulesExcluded(),
+            extension.getVariantAttributes());
 
         applicationPolicyEvaluation =
             new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 1, alerts, "simulated/report");
@@ -104,7 +105,7 @@ public class NexusIqScanTask
 
         File scanFolder = new File(extension.getScanFolderPath());
         List<Module> modules = dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(),
-            extension.getModulesExcluded());
+            extension.getModulesExcluded(), extension.getVariantAttributes());
 
         ScanResult scanResult = iqClient.scan(extension.getApplicationId(), proprietaryConfig, buildProperties(),
             Collections.emptyList(), scanFolder, Collections.emptyMap(), Collections.emptySet(), modules);

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -77,8 +77,9 @@ public class OssIndexAuditTask
       Set<ResolvedDependency> dependencies = getProject().getAllprojects().stream()
           .filter(project -> extension.getModulesIncluded() == null || extension.getModulesIncluded().isEmpty() || extension.getModulesIncluded().contains(project.getName()))
           .filter(project -> extension.getModulesExcluded() == null || !extension.getModulesExcluded().contains(project.getName()))
-          .flatMap(
-              project -> dependenciesFinder.findResolvedDependencies(project, extension.isAllConfigurations()).stream())
+          .flatMap(project -> dependenciesFinder
+              .findResolvedDependencies(project, extension.isAllConfigurations(), extension.getVariantAttributes())
+              .stream())
           .collect(Collectors.toCollection(LinkedHashSet::new));
       BiMap<ResolvedDependency, PackageUrl> dependenciesMap = HashBiMap.create();
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -15,15 +15,17 @@
  */
 package org.sonatype.gradle.plugins.scan.ossindex;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
 
 import groovy.lang.Closure;
-import org.cyclonedx.model.Component;
 import org.apache.commons.lang3.StringUtils;
+import org.cyclonedx.model.Component;
 import org.gradle.api.Project;
 
 public class OssIndexPluginExtension
@@ -69,6 +71,8 @@ public class OssIndexPluginExtension
 
   private Component.Type cycloneDxComponentType;
 
+  private Map<String, String> variantAttributes;
+
   public OssIndexPluginExtension(Project project) {
     username = "";
     password = "";
@@ -84,6 +88,7 @@ public class OssIndexPluginExtension
     excludeCoordinates = new HashSet<>();
     outputFormat = OutputFormat.DEFAULT;
     cycloneDxComponentType = Component.Type.LIBRARY;
+    variantAttributes = Collections.emptyMap();
   }
 
   public String getUsername() {
@@ -237,5 +242,13 @@ public class OssIndexPluginExtension
 
   public void setCycloneDxComponentType(Component.Type cycloneDxComponentType) {
     this.cycloneDxComponentType = cycloneDxComponentType;
+  }
+
+  public Map<String, String> getVariantAttributes() {
+    return variantAttributes;
+  }
+
+  public void setVariantAttributes(Map<String, String> variantAttributes) {
+    this.variantAttributes = variantAttributes;
   }
 }

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -72,98 +72,98 @@ public class DependenciesFinderTest
   @Test
   public void testFindResolvedDependencies_includeCompileDependencies() {
     Project project = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeRuntimeDependencies() {
     Project project = buildProject(RUNTIME_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyCompileAndroidDependencies() {
     Project project = buildProject("_releaseCompile", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyRuntimeApkAndroidDependencies() {
     Project project = buildProject("_releaseApk", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyRuntimeLibraryAndroidDependencies() {
     Project project = buildProject("_releasePublish", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeCompileAndroidDependencies() {
     Project project = buildProject("releaseCompileClasspath", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeRuntimeAndroidDependencies() {
     Project project = buildProject("releaseRuntimeClasspath", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyCompileApkAndroidDependenciesUsingVariant() {
     Project project = buildProject("variantProd_ReleaseCompile", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyRuntimeApkAndroidDependenciesUsingVariant() {
     Project project = buildProject("variantProd_ReleaseApk", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyRuntimeLibraryAndroidDependenciesUsingVariant() {
     Project project = buildProject("variantProd_ReleasePublish", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeAndroidCompileDependenciesUsingVariant() {
     Project project = buildProject("variantProdReleaseCompileClasspath", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeAndroidRuntimeDependenciesUsingVariant() {
     Project project = buildProject("variantProdReleaseRuntimeClasspath", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_omitTestDependencies() {
     Project project = buildProject(TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
     assertThat(result).isEmpty();
   }
 
   @Test
   public void testFindResolvedDependencies_includeTestDependencies() {
     Project project = buildProject(TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, true);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, true, emptyMap());
     assertThat(result).hasSize(1);
   }
 
@@ -172,8 +172,8 @@ public class DependenciesFinderTest
     Project parentProject = ProjectBuilder.builder().withName("parent").build();
     Project childProject = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false, parentProject);
 
-    assertThat(finder.findResolvedDependencies(childProject, false)).hasSize(1);
-    assertThat(finder.findResolvedDependencies(parentProject, false)).isEmpty();
+    assertThat(finder.findResolvedDependencies(childProject, false, emptyMap())).hasSize(1);
+    assertThat(finder.findResolvedDependencies(parentProject, false, emptyMap())).isEmpty();
   }
 
   @Test
@@ -187,7 +187,7 @@ public class DependenciesFinderTest
     when(project.getConfigurations()).thenReturn(configurationContainer);
     when(project.getAllprojects()).thenReturn(Sets.newHashSet(project));
 
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, true);
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, true, emptyMap());
     assertThat(result).hasSize(1);
   }
 

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -60,7 +61,7 @@ public class NexusIqIndexTaskTest
         .setPathname("test-module");
     File file = Paths.get("test-module", "build", SONATYPE_CLM_FOLDER, MODULE_XML_FILE).toFile();
 
-    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet(), anyMap()))
         .thenReturn(Collections.singletonList(module));
     doNothing().when(moduleIoManagerMock).writeModule(file, module);
 
@@ -69,7 +70,7 @@ public class NexusIqIndexTaskTest
     task.setModuleIoManager(moduleIoManagerMock);
     task.saveModule();
 
-    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet());
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet(), anyMap());
     verify(moduleIoManagerMock).writeModule(file, module);
   }
 
@@ -84,7 +85,7 @@ public class NexusIqIndexTaskTest
     File file1 = Paths.get("test-module-1", "build", SONATYPE_CLM_FOLDER, MODULE_XML_FILE).toFile();
     File file2 = Paths.get("test-module-2", "build", SONATYPE_CLM_FOLDER, MODULE_XML_FILE).toFile();
 
-    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet(), anyMap()))
         .thenReturn(Arrays.asList(module1, module2));
     doNothing().when(moduleIoManagerMock).writeModule(file1, module1);
     doNothing().when(moduleIoManagerMock).writeModule(file2, module2);
@@ -94,7 +95,7 @@ public class NexusIqIndexTaskTest
     task.setModuleIoManager(moduleIoManagerMock);
     task.saveModule();
 
-    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet());
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet(), anyMap());
     verify(moduleIoManagerMock).writeModule(file1, module1);
     verify(moduleIoManagerMock).writeModule(file2, module2);
   }
@@ -103,14 +104,14 @@ public class NexusIqIndexTaskTest
   public void testSaveModule_excludeModules() throws IOException {
     Set<String> modulesExcluded = Sets.newHashSet("test-module-1", "test-module-2");
 
-    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), eq(modulesExcluded)))
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), eq(modulesExcluded), anyMap()))
         .thenReturn(Collections.emptyList());
 
     NexusIqIndexTask task = buildIndexTask(modulesExcluded);
     task.setDependenciesFinder(dependenciesFinderMock);
     task.saveModule();
 
-    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), eq(modulesExcluded));
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), eq(modulesExcluded), anyMap());
   }
 
   private NexusIqIndexTask buildIndexTask(Set<String> modulesExcluded) {

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTaskTest.java
@@ -93,7 +93,7 @@ public class NexusIqScanTaskTest
         new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0, Collections.emptyList(), "simulated/report"));
     when(builderMock.build()).thenReturn(iqClientMock);
 
-    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet()))
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet(), anyMap()))
         .thenReturn(Collections.emptyList());
   }
 
@@ -114,7 +114,7 @@ public class NexusIqScanTaskTest
 
     task.scan();
 
-    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet());
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet(), anyMap());
     assertThat(userAgentCaptor.getValue()).matches(USER_AGENT_REGEX);
     verify(iqClientMock).validateServerVersion(anyString());
     verify(iqClientMock).verifyOrCreateApplication(eq(task.getApplicationId()), eq(""));


### PR DESCRIPTION
A Gradle project can have multiple custom variants for the release distribution. That results into having multiple variants matching the `BuildTypeAttr` attribute with the `release` value and the error message looks like this:

```
> Could not resolve all dependencies for configuration 'sonatypeCopyConfiguration0'.
   > Could not resolve project :common-lib.
     Required by:
         project :app
      > The consumer was configured to find a runtime of a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release'. However we cannot choose between the following variants of project :baseapp:
          - ciReleaseRuntimeElements
          - prodReleaseRuntimeElements
        All of them match the consumer attributes:
          - Variant 'ciReleaseRuntimeElements' capability common-lib:1.0.0 declares a runtime of a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release':
              - Unmatched attributes:
                  - Provides attribute 'com.android.build.api.attributes.AgpVersionAttr' with value '7.2.2' but the consumer didn't ask for it
                  - Provides attribute 'com.android.build.api.attributes.ProductFlavor:version' with value 'ci' but the consumer didn't ask for it
                  - Provides attribute 'com.android.build.gradle.internal.attributes.VariantAttr' with value 'ciRelease' but the consumer didn't ask for it
                  - Provides a library but the consumer didn't ask for it
                  - Provides attribute 'org.gradle.jvm.environment' with value 'android' but the consumer didn't ask for it
          - Variant 'prodReleaseRuntimeElements' capability common-lib:1.0.0 declares a runtime of a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release':
              - Unmatched attributes:
                  - Provides attribute 'com.android.build.api.attributes.AgpVersionAttr' with value '7.2.2' but the consumer didn't ask for it
                  - Provides attribute 'com.android.build.api.attributes.ProductFlavor:version' with value 'prod' but the consumer didn't ask for it
                  - Provides attribute 'com.android.build.gradle.internal.attributes.VariantAttr' with value 'prodRelease' but the consumer didn't ask for it
                  - Provides a library but the consumer didn't ask for it
                  - Provides attribute 'org.gradle.jvm.environment' with value 'android' but the consumer didn't ask for it
```

From that output we can see the attribute `com.android.build.api.attributes.ProductFlavor:version` can be use to distinguish between the available variants and since values can be customize on the project, this pull-request adds a new option `variantAttributes` to configure as many attributes as needed to make sure the right variant is matched to get the dependecies from it:

```
nexusIQScan {
    variantAttributes = ['com.android.build.api.attributes.ProductFlavor:version': 'prod']
    ... // other required properties
}

ossIndexAudit {
    variantAttributes = ['com.android.build.api.attributes.ProductFlavor:version': 'prod']
}
```

It relates to the following issue #s:
* An specialization of #128 

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
