### PR TITLE
Set this tasks as Not Compatible with configuration cache

### DIFF
--- a/src/main/java/org/sonatype/gradle/plugins/scan/ScanPlugin.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ScanPlugin.java
@@ -30,15 +30,27 @@ import org.gradle.api.Project;
 
 public class ScanPlugin implements Plugin<Project>
 {
-  private static final boolean IS_GRADLE_MIN_49 = GradleVersion.current().compareTo(GradleVersion.version("4.9-rc-1"))>=0;
+  private static final boolean IS_GRADLE_MIN_4_9 =
+      GradleVersion.current().compareTo(GradleVersion.version("4.9-rc-1")) >= 0;
+
+  private static final boolean IS_GRADLE_MIN_7_4 =
+      GradleVersion.current().compareTo(GradleVersion.version("7.4")) >= 0;
+
   private static final String SONATYPE_GROUP = "Sonatype";
 
+  private static final String TASK_NOT_COMPATIBLE_WITH_CONFIG_CACHE_REASON =
+      "Task needs to access the project configuration";
+
   @Override
+  @SuppressWarnings("deprecation")
   public void apply(Project project) {
     project.getExtensions().create("nexusIQScan", NexusIqPluginScanExtension.class, project);
     createTask(project, "nexusIQScan", NexusIqScanTask.class, task -> {
       task.setGroup(SONATYPE_GROUP);
       task.setDescription("Scan and evaluate the dependencies of the project using Nexus IQ Server.");
+      if (IS_GRADLE_MIN_7_4) {
+        task.notCompatibleWithConfigurationCache(TASK_NOT_COMPATIBLE_WITH_CONFIG_CACHE_REASON);
+      }
     });
 
     project.getExtensions().create("nexusIQIndex", NexusIqPluginIndexExtension.class, project);
@@ -46,17 +58,23 @@ public class ScanPlugin implements Plugin<Project>
       task.setGroup(SONATYPE_GROUP);
       task.setDescription("Saves information about the dependencies of a project into module information "
             + "(module.xml) files that Sonatype CI tools can use to include these dependencies in a scan.");
+      if (IS_GRADLE_MIN_7_4) {
+        task.notCompatibleWithConfigurationCache(TASK_NOT_COMPATIBLE_WITH_CONFIG_CACHE_REASON);
+      }
     });
 
     project.getExtensions().create("ossIndexAudit", OssIndexPluginExtension.class, project);
     createTask(project, "ossIndexAudit", OssIndexAuditTask.class, task -> {
       task.setGroup(SONATYPE_GROUP);
       task.setDescription("Audit the dependencies of the project using OSS Index.");
+      if (IS_GRADLE_MIN_7_4) {
+        task.notCompatibleWithConfigurationCache(TASK_NOT_COMPATIBLE_WITH_CONFIG_CACHE_REASON);
+      }
     });
   }
 
   private static <T extends Task> void createTask(Project project, String name, Class<T> type, Action<? super T> configuration) {
-    if (IS_GRADLE_MIN_49) {
+    if (IS_GRADLE_MIN_4_9) {
       project.getTasks().register(name, type, configuration);
     } else {
       project.getTasks().create(name, type, configuration);


### PR DESCRIPTION
Set this tasks as Not Compatible with configuration cache.

A warning still appears at the end of the output, but the tasks will not fail.

It relates to the following issue #s:
* Fixes #140 