### PR TITLE
#148 Uses the Legacy Violations text in log output

### DIFF
--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
@@ -526,7 +526,7 @@ public abstract class ScanPluginIntegrationTestBase
     final String resultOutput = result.getOutput();
     assertThat(resultOutput).contains("Policy Action: " + policyAction);
     assertThat(resultOutput).contains("Number of components affected: 0 critical, 0 severe, 0 moderate");
-    assertThat(resultOutput).contains("Number of grandfathered policy violations: 0");
+    assertThat(resultOutput).contains("Number of legacy violations: 0");
     assertThat(resultOutput).contains("The detailed report can be viewed online at simulated/report");
     assertThat(resultOutput).contains("Number of components: 1");
   }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
@@ -186,9 +186,8 @@ public class NexusIqScanTask
     message.append(String.format("Number of components affected: %s critical, %s severe, %s moderate\n",
         applicationPolicyEvaluation.getCriticalComponentCount(), applicationPolicyEvaluation.getSevereComponentCount(),
         applicationPolicyEvaluation.getModerateComponentCount()));
-    message.append(
-        String.format("Number of grandfathered policy violations: %s\n",
-            applicationPolicyEvaluation.getGrandfatheredPolicyViolationCount()));
+    message.append(String.format("Number of legacy violations: %s\n",
+        applicationPolicyEvaluation.getGrandfatheredPolicyViolationCount()));
     message.append(String.format("Number of components: %s\n", applicationPolicyEvaluation.getTotalComponentCount()));
     message.append("The detailed report can be viewed online at ").append(reportUrl).append("\n");
 


### PR DESCRIPTION
Updates the log output to introduce the concept [Legacy Violations](https://help.sonatype.com/iqserver/product-information/release-notes#ReleaseNotes-EmbracingInclusionwithLegacyViolations):
```
Policy Action: None
Number of components affected: 2 critical, 0 severe, 0 moderate
Number of legacy violations: 1
Number of components: 3
```

This works fine both in previous versions of IQ Server and after the Legacy Violations concept was introduced.

It relates to the following issue #s:
* Fixes #148
