### PR TITLE
#139 Allows to set additional scan targets for IQ evaluations

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Gradle can be used to build projects developed in various programming languages.
 
 ```
 plugins {
-  id 'org.sonatype.gradle.plugins.scan' version '2.6.0' // Update the version as needed
+  id 'org.sonatype.gradle.plugins.scan' version '2.7.0' // Update the version as needed
 }
 ```
 
 - Or `build.gradle.kts`:
 ```
 plugins {
-    id ("org.sonatype.gradle.plugins.scan") version "2.6.0" // Update the version as needed
+    id ("org.sonatype.gradle.plugins.scan") version "2.7.0" // Update the version as needed
 }
 ```
 
@@ -175,6 +175,7 @@ nexusIQScan {
 
     // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at the section "How to Deal with Multiple Release Variants" below in this doc.
     variantAttributes = ['com.android.build.api.attributes.ProductFlavor:version': 'prod', 'other.attribute': 'other value'] // Optional, use it only when the plugin can't match a variant on its own
+    scanTargets = ['package-lock.json', '**/*.lock'] // Optional. Ant-like glob patterns for relative paths (to the project's folder) to select additional files to be scanned and evaluated.
 }
 ```
 
@@ -195,6 +196,7 @@ nexusIQScan {
 
     // For projects using multiple custom variants for the release distribution, a Map can be set with the attributes names and values to match the specific variant. See more at the section "How to Deal with Multiple Release Variants" below in this doc.
     variantAttributes = mapOf("com.android.build.api.attributes.ProductFlavor:version" to "prod", "other.attribute" to "other value") // Optional, use it only when the plugin can't match a variant on its own
+    scanTargets = listOf("package-lock.json", "**/*.lock") // Optional. Ant-like glob patterns for relative paths (to the project's folder) to select additional files to be scanned and evaluated.
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -77,11 +77,11 @@ dependencies {
   implementation "com.sonatype.nexus:nexus-platform-api:$nexusPlatformApiVersion"
   implementation "org.sonatype.ossindex:ossindex-service-client:$ossIndexClientVersion"
   implementation "ch.qos.logback:logback-classic:$logbackVersion"
+  implementation "commons-io:commons-io:$commonsIoVersion"
 
   testImplementation gradleTestKit()
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.assertj:assertj-core:$assertJVersion"
-  testImplementation "commons-io:commons-io:$commonsIoVersion"
   testImplementation "org.powermock:powermock-module-junit4:$powermockVersion"
   testImplementation "org.powermock:powermock-api-mockito2:$powermockVersion"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ logbackVersion=1.2.11
 junitVersion=4.13.2
 powermockVersion=2.0.9
 assertJVersion=3.23.1
-commonsIoVersion=2.11.0
+commonsIoVersion=2.15.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,10 +15,10 @@
 #
 
 group=org.sonatype.gradle.plugins
-version=2.6.3-SNAPSHOT
+version=2.7.0-SNAPSHOT
 release.useAutomaticVersion=true
 
-nexusPlatformApiVersion=4.0.3-01
+nexusPlatformApiVersion=4.0.7-01
 ossIndexClientVersion=1.8.1
 logbackVersion=1.2.11
 

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
@@ -58,6 +58,8 @@ public class NexusIqPluginScanExtension
 
   private Map<String, String> variantAttributes;
 
+  private Set<String> scanTargets;
+
   public NexusIqPluginScanExtension(Project project) {
     stage = Stage.ID_BUILD;
     organizationId = "";
@@ -68,6 +70,7 @@ public class NexusIqPluginScanExtension
     dirIncludes = "";
     dirExcludes = "";
     variantAttributes = Collections.emptyMap();
+    scanTargets = Collections.emptySet();
   }
 
   public String getUsername() {
@@ -189,5 +192,13 @@ public class NexusIqPluginScanExtension
 
   public void setVariantAttributes(Map<String, String> variantAttributes) {
     this.variantAttributes = variantAttributes;
+  }
+
+  public Set<String> getScanTargets() {
+    return scanTargets;
+  }
+
+  public void setScanTargets(Set<String> scanTargets) {
+    this.scanTargets = scanTargets;
   }
 }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
@@ -173,14 +173,15 @@ public class NexusIqScanTask
 
   private List<File> buildScanTargets() {
     if (extension.getScanTargets() != null && !extension.getScanTargets().isEmpty()) {
+      // Using the same approach as the Jenkins plugin for consistency
       DirectoryScanner directoryScanner = new DirectoryScanner();
       directoryScanner.setBasedir(extension.getScanFolderPath());
       directoryScanner.setIncludes(extension.getScanTargets().toArray(new String[extension.getScanTargets().size()]));
       directoryScanner.addDefaultExcludes();
       directoryScanner.scan();
       return Stream
-          .concat(stream(directoryScanner.getIncludedDirectories()), stream(directoryScanner.getIncludedFiles())) //
-          .map(file -> new File(extension.getScanFolderPath(), file)) //
+          .concat(stream(directoryScanner.getIncludedDirectories()), stream(directoryScanner.getIncludedFiles()))
+          .map(file -> new File(extension.getScanFolderPath(), file))
           .collect(Collectors.toList());
     }
     return Collections.emptyList();

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.sonatype.insight.brain.client.PolicyAction;
 import com.sonatype.insight.scan.module.model.Module;
@@ -42,6 +44,7 @@ import org.sonatype.gradle.plugins.scan.common.DependenciesFinder;
 import org.sonatype.gradle.plugins.scan.common.PluginVersionUtils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.Input;
@@ -49,6 +52,8 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.util.Arrays.stream;
 
 public class NexusIqScanTask
     extends DefaultTask
@@ -108,7 +113,7 @@ public class NexusIqScanTask
             extension.getModulesExcluded(), extension.getVariantAttributes());
 
         ScanResult scanResult = iqClient.scan(extension.getApplicationId(), proprietaryConfig, buildProperties(),
-            Collections.emptyList(), scanFolder, Collections.emptyMap(), Collections.emptySet(), modules);
+            buildScanTargets(), scanFolder, Collections.emptyMap(), Collections.emptySet(), modules);
 
         File jsonResultsFile = null;
         if (StringUtils.isNotBlank(extension.getResultFilePath())) {
@@ -164,6 +169,21 @@ public class NexusIqScanTask
       properties.setProperty("dirExcludes", extension.getDirExcludes());
     }
     return properties;
+  }
+
+  private List<File> buildScanTargets() {
+    if (extension.getScanTargets() != null && !extension.getScanTargets().isEmpty()) {
+      DirectoryScanner directoryScanner = new DirectoryScanner();
+      directoryScanner.setBasedir(extension.getScanFolderPath());
+      directoryScanner.setIncludes(extension.getScanTargets().toArray(new String[extension.getScanTargets().size()]));
+      directoryScanner.addDefaultExcludes();
+      directoryScanner.scan();
+      return Stream
+          .concat(stream(directoryScanner.getIncludedDirectories()), stream(directoryScanner.getIncludedFiles())) //
+          .map(file -> new File(extension.getScanFolderPath(), file)) //
+          .collect(Collectors.toList());
+    }
+    return Collections.emptyList();
   }
 
   private void logReport(PolicyAction policyAction, ApplicationPolicyEvaluation applicationPolicyEvaluation) {


### PR DESCRIPTION
Allows to set extra paths (or patterns) to scan additional files.

For example:
```
scanTargets = ['package-lock.json', '**/*.lock']
```

It relates to the following issue #s:
* Fixes #139 

cc @bhamail / @DarthHater / @shaikhu
