### PR TITLE
#147 Drop usage of shadow plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ Some basic examples follow, which we strongly advise reading :)
 
 After doing so, specific usage on CI tools can be found at https://github.com/guillermo-varela/example-scan-gradle-plugin
 
+Also, when running the tasks please set the log level to `INFO` to see results using `-i` or `--info`:
+
+```
+./gradlew ossIndexAudit --info
+./gradlew nexusIQScan --info
+```
+
 ### OSS Index
 OSS Index can be used without any extra configuration, but to avoid reaching the limit for anonymous queries every user
 is encouraged to create a free account on [OSS Index](https://ossindex.sonatype.org/user/signin) and use the credentials

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
-
 plugins {
   id 'java-gradle-plugin'
   id 'maven-publish'
@@ -7,7 +5,6 @@ plugins {
   id 'net.researchgate.release' version '3.0.0'
   id 'io.codearte.nexus-staging' version '0.30.0'
   id 'com.gradle.plugin-publish' version '0.21.0'
-  id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 apply from: 'gradle/integration-test.gradle'
@@ -49,21 +46,6 @@ jar {
   }
 }
 
-shadowJar {
-  mergeServiceFiles()
-  archiveClassifier.set('')
-}
-
-task relocateShadowJar(type: ConfigureShadowRelocation) {
-  target = tasks.shadowJar
-}
-
-tasks.shadowJar.dependsOn tasks.relocateShadowJar
-
-artifacts {
-  archives shadowJar
-}
-
 allprojects {
   repositories {
     mavenCentral()
@@ -71,9 +53,6 @@ allprojects {
 }
 
 dependencies {
-  shadow localGroovy()
-  shadow gradleApi()
-
   implementation ("com.sonatype.nexus:nexus-platform-api:$nexusPlatformApiVersion") {
     exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit'
   }
@@ -89,11 +68,6 @@ dependencies {
   testImplementation "org.powermock:powermock-api-mockito2:$powermockVersion"
 }
 
-// Remove the gradleApi so it isn't merged into the jar file when applying 'shadow'
-configurations.named(JavaPlugin.API_CONFIGURATION_NAME) {
-  dependencies.remove(project.dependencies.gradleApi())
-}
-
 processResources {
   filesMatching('com/sonatype/insight/client.properties') {
     expand(project.properties)
@@ -102,14 +76,6 @@ processResources {
 
 test {
   maxHeapSize = '512m'
-}
-
-sourceSets {
-  test {
-    // Groovy and Gradle libraries on the new shadow configuration need to be available for tests
-    compileClasspath = configurations.shadow + compileClasspath
-    runtimeClasspath = configurations.shadow + runtimeClasspath
-  }
 }
 
 publishing {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -26,4 +26,5 @@
   <root level="INFO">
     <appender-ref ref="CONSOLE" />
   </root>
+  <logger name="de.schlichtherle.truezip" level="ERROR" />
 </configuration>


### PR DESCRIPTION
Plugin is no longer deployed as an uber jar. This PR drops all usage/configuration of the shadown plugin.

Unintended consequence
It appears by dropping shadowing we are no longer using slf4j logger at runtime, but default gradle logging implementation. This means unless `--info` is supplied to the gradle command, the logging information will not be displayed. 

It relates to the following issue #s:
* Fixes #147 

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
