### PR TITLE
#145 Include only runtime configurations

### DIFF
--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTask.java
@@ -60,7 +60,7 @@ public class NexusIqIndexTask
   public void saveModule() {
     try {
       List<Module> modules = dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(),
-          extension.getModulesExcluded(), extension.getVariantAttributes());
+          extension.isRuntimeConfigurationsOnly(), extension.getModulesExcluded(), extension.getVariantAttributes());
       List<File> files = new ArrayList<>(modules.size());
 
       for (Module module : modules) {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqPluginIndexExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqPluginIndexExtension.java
@@ -25,6 +25,8 @@ public class NexusIqPluginIndexExtension
 {
   private boolean allConfigurations;
 
+  private boolean runtimeConfigurationsOnly;
+
   private Set<String> modulesExcluded;
 
   private Map<String, String> variantAttributes;
@@ -40,6 +42,14 @@ public class NexusIqPluginIndexExtension
 
   public void setAllConfigurations(boolean allConfigurations) {
     this.allConfigurations = allConfigurations;
+  }
+
+  public boolean isRuntimeConfigurationsOnly() {
+    return runtimeConfigurationsOnly;
+  }
+
+  public void setRuntimeConfigurationsOnly(boolean runtimeConfigurationsOnly) {
+    this.runtimeConfigurationsOnly = runtimeConfigurationsOnly;
   }
 
   public Set<String> getModulesExcluded() {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqPluginScanExtension.java
@@ -46,6 +46,8 @@ public class NexusIqPluginScanExtension
 
   private boolean allConfigurations;
 
+  private boolean runtimeConfigurationsOnly;
+
   private boolean simulationEnabled;
 
   private String simulatedPolicyActionId;
@@ -144,6 +146,14 @@ public class NexusIqPluginScanExtension
 
   public void setAllConfigurations(boolean allConfigurations) {
     this.allConfigurations = allConfigurations;
+  }
+
+  public boolean isRuntimeConfigurationsOnly() {
+    return runtimeConfigurationsOnly;
+  }
+
+  public void setRuntimeConfigurationsOnly(boolean runtimeConfigurationsOnly) {
+    this.runtimeConfigurationsOnly = runtimeConfigurationsOnly;
   }
 
   public boolean isSimulationEnabled() {

--- a/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTask.java
@@ -87,8 +87,8 @@ public class NexusIqScanTask
               Collections.singletonList(new Action(extension.getSimulatedPolicyActionId()))));
         }
 
-        dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(), extension.getModulesExcluded(),
-            extension.getVariantAttributes());
+        dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(),
+            extension.isRuntimeConfigurationsOnly(), extension.getModulesExcluded(), extension.getVariantAttributes());
 
         applicationPolicyEvaluation =
             new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 1, alerts, "simulated/report");
@@ -110,7 +110,7 @@ public class NexusIqScanTask
 
         File scanFolder = new File(extension.getScanFolderPath());
         List<Module> modules = dependenciesFinder.findModules(getProject(), extension.isAllConfigurations(),
-            extension.getModulesExcluded(), extension.getVariantAttributes());
+            extension.isRuntimeConfigurationsOnly(), extension.getModulesExcluded(), extension.getVariantAttributes());
 
         ScanResult scanResult = iqClient.scan(extension.getApplicationId(), proprietaryConfig, buildProperties(),
             buildScanTargets(), scanFolder, Collections.emptyMap(), Collections.emptySet(), modules);

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -78,7 +78,8 @@ public class OssIndexAuditTask
           .filter(project -> extension.getModulesIncluded() == null || extension.getModulesIncluded().isEmpty() || extension.getModulesIncluded().contains(project.getName()))
           .filter(project -> extension.getModulesExcluded() == null || !extension.getModulesExcluded().contains(project.getName()))
           .flatMap(project -> dependenciesFinder
-              .findResolvedDependencies(project, extension.isAllConfigurations(), extension.getVariantAttributes())
+              .findResolvedDependencies(project, extension.isAllConfigurations(),
+                  extension.isRuntimeConfigurationsOnly(), extension.getVariantAttributes())
               .stream())
           .collect(Collectors.toCollection(LinkedHashSet::new));
       BiMap<ResolvedDependency, PackageUrl> dependenciesMap = HashBiMap.create();

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -47,6 +47,8 @@ public class OssIndexPluginExtension
 
   private boolean allConfigurations;
 
+  private boolean runtimeConfigurationsOnly;
+
   private Set<String> modulesIncluded;
 
   private Set<String> modulesExcluded;
@@ -137,6 +139,14 @@ public class OssIndexPluginExtension
 
   public void setAllConfigurations(boolean allConfigurations) {
     this.allConfigurations = allConfigurations;
+  }
+
+  public boolean isRuntimeConfigurationsOnly() {
+    return runtimeConfigurationsOnly;
+  }
+
+  public void setRuntimeConfigurationsOnly(boolean runtimeConfigurationsOnly) {
+    this.runtimeConfigurationsOnly = runtimeConfigurationsOnly;
   }
 
   public Set<String> getModulesIncluded() {

--- a/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinderTest.java
@@ -72,98 +72,98 @@ public class DependenciesFinderTest
   @Test
   public void testFindResolvedDependencies_includeCompileDependencies() {
     Project project = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeRuntimeDependencies() {
     Project project = buildProject(RUNTIME_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyCompileAndroidDependencies() {
     Project project = buildProject("_releaseCompile", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyRuntimeApkAndroidDependencies() {
     Project project = buildProject("_releaseApk", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyRuntimeLibraryAndroidDependencies() {
     Project project = buildProject("_releasePublish", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeCompileAndroidDependencies() {
     Project project = buildProject("releaseCompileClasspath", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeRuntimeAndroidDependencies() {
     Project project = buildProject("releaseRuntimeClasspath", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyCompileApkAndroidDependenciesUsingVariant() {
     Project project = buildProject("variantProd_ReleaseCompile", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyRuntimeApkAndroidDependenciesUsingVariant() {
     Project project = buildProject("variantProd_ReleaseApk", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeLegacyRuntimeLibraryAndroidDependenciesUsingVariant() {
     Project project = buildProject("variantProd_ReleasePublish", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeAndroidCompileDependenciesUsingVariant() {
     Project project = buildProject("variantProdReleaseCompileClasspath", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_includeAndroidRuntimeDependenciesUsingVariant() {
     Project project = buildProject("variantProdReleaseRuntimeClasspath", true);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedDependencies_omitTestDependencies() {
     Project project = buildProject(TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, false, false, emptyMap());
     assertThat(result).isEmpty();
   }
 
   @Test
   public void testFindResolvedDependencies_includeTestDependencies() {
     Project project = buildProject(TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, true, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, true, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
@@ -172,8 +172,8 @@ public class DependenciesFinderTest
     Project parentProject = ProjectBuilder.builder().withName("parent").build();
     Project childProject = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false, parentProject);
 
-    assertThat(finder.findResolvedDependencies(childProject, false, emptyMap())).hasSize(1);
-    assertThat(finder.findResolvedDependencies(parentProject, false, emptyMap())).isEmpty();
+    assertThat(finder.findResolvedDependencies(childProject, false, false, emptyMap())).hasSize(1);
+    assertThat(finder.findResolvedDependencies(parentProject, false, false, emptyMap())).isEmpty();
   }
 
   @Test
@@ -187,49 +187,49 @@ public class DependenciesFinderTest
     when(project.getConfigurations()).thenReturn(configurationContainer);
     when(project.getAllprojects()).thenReturn(Sets.newHashSet(project));
 
-    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, true, emptyMap());
+    Set<ResolvedDependency> result = finder.findResolvedDependencies(project, true, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedArtifacts_includeCompileDependencies() {
     Project project = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false, emptyMap());
+    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedArtifacts_includeRuntimeDependencies() {
     Project project = buildProject(RUNTIME_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false, emptyMap());
+    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedArtifacts_includeAndroidCompileDependencies() {
     Project project = buildProject("releaseCompileClasspath", true);
-    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false, emptyMap());
+    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedArtifacts_includeAndroidRuntimeDependencies() {
     Project project = buildProject("releaseRuntimeClasspath", true);
-    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false, emptyMap());
+    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
   @Test
   public void testFindResolvedArtifacts_omitTestDependencies() {
     Project project = buildProject(TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false, emptyMap());
+    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, false, false, emptyMap());
     assertThat(result).isEmpty();
   }
 
   @Test
   public void testFindResolvedArtifacts_includeTestDependencies() {
     Project project = buildProject(TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, true, emptyMap());
+    Set<ResolvedArtifact> result = finder.findResolvedArtifacts(project, true, false, emptyMap());
     assertThat(result).hasSize(1);
   }
 
@@ -270,7 +270,7 @@ public class DependenciesFinderTest
   @Test
   public void testFindModules_singleModule() {
     Project project = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false);
-    List<Module> modules = finder.findModules(project, false, emptySet(), emptyMap());
+    List<Module> modules = finder.findModules(project, false, false, emptySet(), emptyMap());
 
     assertThat(modules).hasSize(1);
 
@@ -291,7 +291,7 @@ public class DependenciesFinderTest
   public void testFindModules_multiModule() {
     Project parentProject = ProjectBuilder.builder().withName("parent").build();
     Project childProject = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false, parentProject);
-    List<Module> modules = finder.findModules(parentProject, false, emptySet(), emptyMap());
+    List<Module> modules = finder.findModules(parentProject, false, false, emptySet(), emptyMap());
 
     assertThat(modules).hasSize(2);
 
@@ -319,7 +319,7 @@ public class DependenciesFinderTest
     Project parentProject = ProjectBuilder.builder().withName("parent").build();
     Project childProject = buildProject(COMPILE_CLASSPATH_CONFIGURATION_NAME, false, parentProject);
     List<Module> modules =
-        finder.findModules(parentProject, false, Collections.singleton(childProject.getName()), emptyMap());
+        finder.findModules(parentProject, false, false, Collections.singleton(childProject.getName()), emptyMap());
 
     assertThat(modules).hasSize(1);
     assertThat(modules.get(0).getId()).isEqualTo(parentProject.getName());

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/index/NexusIqIndexTaskTest.java
@@ -61,7 +61,7 @@ public class NexusIqIndexTaskTest
         .setPathname("test-module");
     File file = Paths.get("test-module", "build", SONATYPE_CLM_FOLDER, MODULE_XML_FILE).toFile();
 
-    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet(), anyMap()))
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), eq(false), anySet(), anyMap()))
         .thenReturn(Collections.singletonList(module));
     doNothing().when(moduleIoManagerMock).writeModule(file, module);
 
@@ -70,7 +70,7 @@ public class NexusIqIndexTaskTest
     task.setModuleIoManager(moduleIoManagerMock);
     task.saveModule();
 
-    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet(), anyMap());
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), eq(false), anySet(), anyMap());
     verify(moduleIoManagerMock).writeModule(file, module);
   }
 
@@ -85,7 +85,7 @@ public class NexusIqIndexTaskTest
     File file1 = Paths.get("test-module-1", "build", SONATYPE_CLM_FOLDER, MODULE_XML_FILE).toFile();
     File file2 = Paths.get("test-module-2", "build", SONATYPE_CLM_FOLDER, MODULE_XML_FILE).toFile();
 
-    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet(), anyMap()))
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), eq(false), anySet(), anyMap()))
         .thenReturn(Arrays.asList(module1, module2));
     doNothing().when(moduleIoManagerMock).writeModule(file1, module1);
     doNothing().when(moduleIoManagerMock).writeModule(file2, module2);
@@ -95,7 +95,7 @@ public class NexusIqIndexTaskTest
     task.setModuleIoManager(moduleIoManagerMock);
     task.saveModule();
 
-    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet(), anyMap());
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), eq(false), anySet(), anyMap());
     verify(moduleIoManagerMock).writeModule(file1, module1);
     verify(moduleIoManagerMock).writeModule(file2, module2);
   }
@@ -104,14 +104,14 @@ public class NexusIqIndexTaskTest
   public void testSaveModule_excludeModules() throws IOException {
     Set<String> modulesExcluded = Sets.newHashSet("test-module-1", "test-module-2");
 
-    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), eq(modulesExcluded), anyMap()))
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), eq(false), eq(modulesExcluded), anyMap()))
         .thenReturn(Collections.emptyList());
 
     NexusIqIndexTask task = buildIndexTask(modulesExcluded);
     task.setDependenciesFinder(dependenciesFinderMock);
     task.saveModule();
 
-    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), eq(modulesExcluded), anyMap());
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), eq(false), eq(modulesExcluded), anyMap());
   }
 
   private NexusIqIndexTask buildIndexTask(Set<String> modulesExcluded) {

--- a/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/nexus/iq/scan/NexusIqScanTaskTest.java
@@ -101,7 +101,7 @@ public class NexusIqScanTaskTest
         new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0, Collections.emptyList(), "simulated/report"));
     when(builderMock.build()).thenReturn(iqClientMock);
 
-    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), anySet(), anyMap()))
+    when(dependenciesFinderMock.findModules(any(Project.class), eq(false), eq(false), anySet(), anyMap()))
         .thenReturn(Collections.emptyList());
   }
 
@@ -122,7 +122,7 @@ public class NexusIqScanTaskTest
 
     task.scan();
 
-    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), anySet(), anyMap());
+    verify(dependenciesFinderMock).findModules(any(Project.class), eq(false), eq(false), anySet(), anyMap());
     assertThat(userAgentCaptor.getValue()).matches(USER_AGENT_REGEX);
     verify(iqClientMock).validateServerVersion(anyString());
     verify(iqClientMock).verifyOrCreateApplication(eq(task.getApplicationId()), eq(""));


### PR DESCRIPTION
Includes dependencies only from the runtime configurations. That is, no compile dependecies, just the ones that end up in the packaged application by using a new configuration property `runtimeConfigurationsOnly`:

```groovy
nexusIQScan {
  username = 'user'
  password = 'password'
  serverUrl = 'http://localhost:8070'
  applicationId = project.name
  runtimeConfigurationsOnly = true
}
```

(If there are changes to user behavior in general, please make sure to
update the docs, as well)

It relates to the following issue #s:
* Fixes #145 

cc @bhamail / @DarthHater / @shaikhu