### PR TITLE
Upgrade to safe version of JGit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   implementation ("com.sonatype.nexus:nexus-platform-api:$nexusPlatformApiVersion") {
     exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit'
   }
-  implementation 'org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r'
+  implementation 'org.eclipse.jgit:org.eclipse.jgit:5.13.3.202401111512-r'
   implementation "org.sonatype.ossindex:ossindex-service-client:$ossIndexClientVersion"
   implementation "ch.qos.logback:logback-classic:$logbackVersion"
   implementation "commons-io:commons-io:$commonsIoVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,10 @@ dependencies {
   shadow localGroovy()
   shadow gradleApi()
 
-  implementation "com.sonatype.nexus:nexus-platform-api:$nexusPlatformApiVersion"
+  implementation ("com.sonatype.nexus:nexus-platform-api:$nexusPlatformApiVersion") {
+    exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit'
+  }
+  implementation 'org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r'
   implementation "org.sonatype.ossindex:ossindex-service-client:$ossIndexClientVersion"
   implementation "ch.qos.logback:logback-classic:$logbackVersion"
   implementation "commons-io:commons-io:$commonsIoVersion"


### PR DESCRIPTION
Investigate and upgrade to a safe version of JGit which is still compatible with Java 8.

It relates to the following issue #s:
* Fixes #152 

cc @bhamail / @DarthHater / @guillermo-varela 
