### PR TITLE
#155 add failOnDetection plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ plugins {
 }
 ```
 
-Some basic examples will be provided next, which we strongly advice to read :)
+Some basic examples follow, which we strongly advise reading :)
 
 After doing so, specific usage on CI tools can be found at https://github.com/guillermo-varela/example-scan-gradle-plugin
 
@@ -102,6 +102,10 @@ ossIndexAudit {
     // ossIndexAudit can be configured to exclude vulnerabilities from matching
     excludeVulnerabilityIds = ['39d74cc8-457a-4e57-89ef-a258420138c5'] // list containing ids of vulnerabilities to be ignored
     excludeCoordinates = ['commons-fileupload:commons-fileupload:1.3'] // list containing coordinate of components which if vulnerable should be ignored
+
+    // By default, the audit scan will fail the task/build if any vulnerabilities are found.
+    // Set this to 'false' to allow the task to succeed even when vulnerabilities are detected.
+    failOnDetection = true
 
     // Output options
     outputFormat = 'DEFAULT' // Optional, other values are: 'DEPENDENCY_GRAPH' prints dependency graph showing direct/transitive dependencies, 'JSON_CYCLONE_DX_1_4' prints a CycloneDX 1.4 SBOM in JSON format.
@@ -141,6 +145,10 @@ ossIndexAudit {
         listOf("39d74cc8-457a-4e57-89ef-a258420138c5") // list containing ids of vulnerabilities to be ignored
     excludeCoordinates =
         listOf("commons-fileupload:commons-fileupload:1.3") // list containing coordinate of components which if vulnerable should be ignored
+
+    // By default, the audit scan will fail the task/build if any vulnerabilities are found.
+    // Set this to 'false' to allow the task to succeed even when vulnerabilities are detected.
+    failOnDetection = true
 
     // Output options
     outputFormat = "DEFAULT" // Optional, other values are: "DEPENDENCY_GRAPH" prints dependency graph showing direct/transitive dependencies, "JSON_CYCLONE_DX_1_4" prints a CycloneDX 1.4 SBOM in JSON format.

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTask.java
@@ -121,7 +121,7 @@ public class OssIndexAuditTask
       throw new GradleException("Could not audit the project: " + e.getMessage(), e);
     }
 
-    if (hasVulnerabilities) {
+    if (hasVulnerabilities && extension.isFailOnDetection()) {
       throw new GradleException("Vulnerabilities detected, check log output to review them");
     }
   }

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexPluginExtension.java
@@ -63,6 +63,8 @@ public class OssIndexPluginExtension
 
   private boolean printBanner;
 
+  private boolean failOnDetection;
+
   private Set<String> excludeVulnerabilityIds;
 
   private Set<String> excludeCoordinates;
@@ -84,6 +86,7 @@ public class OssIndexPluginExtension
     colorEnabled = true;
     showAll = false;
     printBanner = true;
+    failOnDetection = true;
     excludeVulnerabilityIds = new HashSet<>();
     excludeCoordinates = new HashSet<>();
     outputFormat = OutputFormat.DEFAULT;
@@ -210,6 +213,14 @@ public class OssIndexPluginExtension
 
   public void setPrintBanner(boolean printBanner) {
     this.printBanner = printBanner;
+  }
+
+  public boolean isFailOnDetection() {
+    return failOnDetection;
+  }
+
+  public void setFailOnDetection(boolean failOnDetection) {
+    this.failOnDetection = failOnDetection;
   }
 
   public Set<String> getExcludeVulnerabilityIds() {

--- a/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
+++ b/src/test/java/org/sonatype/gradle/plugins/scan/ossindex/OssIndexAuditTaskTest.java
@@ -44,6 +44,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -87,6 +88,16 @@ public class OssIndexAuditTaskTest
     assertThatThrownBy(taskSpy::audit)
         .isInstanceOf(GradleException.class)
         .hasMessageContaining("Vulnerabilities detected, check log output to review them");
+
+    verify(ossIndexClientMock).requestComponentReports(eq(Collections.singletonList(COMMONS_COLLECTIONS_PURL)));
+  }
+
+  @Test
+  public void testAudit_vulnerabilitiesNoFailOnDetection() throws Exception {
+    setupComponentReport(true);
+    OssIndexAuditTask taskSpy = buildAuditTaskSpy(false, (project, extension) -> extension.setFailOnDetection(false));
+
+    assertThatCode(taskSpy::audit).doesNotThrowAnyException();
 
     verify(ossIndexClientMock).requestComponentReports(eq(Collections.singletonList(COMMONS_COLLECTIONS_PURL)));
   }


### PR DESCRIPTION
This adds a `failOnDetection` setting to the OssIndexAudit extension.

This pull request makes the following changes:
* Additional field to the OssIndexAuditExtension
* Unit test for this setting
* Update to README

The default value, `false`, has no effect on the existing behavior. But if set to `true` the OssIndexAudit task will not fail when vulnerabilities are detected. This allows builds to generate a report as part of a larger pipeline and decide for themselves what to do with the findings.

The change is pretty small and simple. Maybe too simple. It doesn't touch anything with the Nexus IQ -- I'm not sure if that is needed or not.

It relates to the following issue #s:
* #155

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
