### PR TITLE
Check if a child dependency was already included as compileOnly

### DIFF
--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -429,7 +429,9 @@ public class DependenciesFinder
   }
 
   private void fillAllChildDependencies(ResolvedDependency resolvedDependency, Set<String> dependenciesIds) {
-    dependenciesIds.add(getResolvedDependencyId(resolvedDependency));
+    if (!dependenciesIds.add(getResolvedDependencyId(resolvedDependency))) {
+      return;
+    }
 
     if (resolvedDependency.getChildren() != null) {
       for (ResolvedDependency child : resolvedDependency.getChildren()) {


### PR DESCRIPTION
It relates to the following issue #s:
* Fixes #161