### PR TITLE
read secrets/env vars in GHAction Context to vars readable during CI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
         run: ./gradlew jreleaserFullRelease -Dorg.gradle.daemon=false --stacktrace -x test -x integrationTest
         env:
           RELEASE_BUILD: 'true'
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_GPG_SECRET_KEY_BASE64: ${{ secrets.GPG_SIGNING_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY_BASE64: ${{ env.JRELEASER_GPG_PUBLIC_KEY_BASE64 }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -167,8 +167,10 @@ jreleaser {
 
 if (System.getenv('RELEASE_BUILD') == 'true') {
   signing {
-    def final encodedKey = System.getenv('GPG_SIGNING_KEY')
+    def final encodedKey = System.getenv('JRELEASER_GPG_SECRET_KEY_BASE64')
     def final signingKey = new String(encodedKey.decodeBase64())
+    // Todo Set system property for key here??? Is this property setting visible elsewhere?
+    System.setProperty('jreleaser.gpg.secret.key', signingKey)
     allprojects {
       println 'setup gpg signing with in-memory key'
       useInMemoryPgpKeys(
@@ -177,6 +179,11 @@ if (System.getenv('RELEASE_BUILD') == 'true') {
       )
     }
     sign publishing.publications.maven
+
+    def final encodedPublicKey = System.getenv('JRELEASER_GPG_PUBLIC_KEY_BASE64')
+    def final publicKey = new String(encodedPublicKey.decodeBase64())
+    // Todo Set system property for public key here???
+    System.setProperty('jreleaser.gpg.public.key', publicKey)
   }
 }
 


### PR DESCRIPTION
Trying to make GHAction release happy with JReleaser.

Matthew, please review and try some stuff out. Delete comments/code as you see fit. Definitely some guessing on my part here.