### PR TITLE
Only process Java-related configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ Gradle can be used to build projects developed in various programming languages.
 
 ```
 plugins {
-  id 'org.sonatype.gradle.plugins.scan' version '3.1.0' // Update the version as needed
+  id 'org.sonatype.gradle.plugins.scan' version '3.1.1' // Update the version as needed
 }
 ```
 
 - Or `build.gradle.kts`:
 ```
 plugins {
-    id ("org.sonatype.gradle.plugins.scan") version "3.1.0" // Update the version as needed
+    id ("org.sonatype.gradle.plugins.scan") version "3.1.1" // Update the version as needed
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,5 @@
 #
 
 group=org.sonatype.gradle.plugins
-version=3.1.0-SNAPSHOT
+version=3.1.1-SNAPSHOT
 release.useAutomaticVersion=true

--- a/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/common/DependenciesFinder.java
@@ -42,6 +42,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting;
 
@@ -276,6 +277,11 @@ public class DependenciesFinder
   }
 
   private boolean isAcceptableConfiguration(Configuration configuration, boolean allConfigurations) {
+    Usage usage = configuration.getAttributes().getAttribute(Usage.USAGE_ATTRIBUTE);
+    if (usage != null && !usage.getName().equals(Usage.JAVA_API) && !usage.getName().equals(Usage.JAVA_RUNTIME)) {
+      return false;
+    }
+
     if (allConfigurations) {
       return configuration.isCanBeResolved();
     }


### PR DESCRIPTION
From https://github.com/sonatype-nexus-community/scan-gradle-plugin/issues/175#issuecomment-2867002877

We should be processing metadata-related configurations.

It relates to the following issue #s:
* Fixes #175

cc @bhamail / @DarthHater / @shaikhu
