### PR TITLE
Use the Shadow plugin to shade and relocate dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@
 
 [![Gradle Plugins Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/org/sonatype/gradle/plugins/scan/org.sonatype.gradle.plugins.scan.gradle.plugin/maven-metadata.xml.svg?colorB=007ec6&label=Gradle%20Plugins%20Portal)](https://plugins.gradle.org/plugin/org.sonatype.gradle.plugins.scan)
 
-[![CircleCI Build Status](https://circleci.com/gh/sonatype-nexus-community/scan-gradle-plugin.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/sonatype-nexus-community/scan-gradle-plugin) 
-
 Gradle plugin that scans the dependencies of a Gradle project using Sonatype platforms: OSS Index and Nexus IQ Server.
 
 ## Compile and Publish to Local Maven Cache
@@ -66,14 +64,14 @@ Gradle can be used to build projects developed in various programming languages.
 
 ```
 plugins {
-  id 'org.sonatype.gradle.plugins.scan' version '3.1.1' // Update the version as needed
+  id 'org.sonatype.gradle.plugins.scan' version '3.1.3' // Update the version as needed
 }
 ```
 
 - Or `build.gradle.kts`:
 ```
 plugins {
-    id ("org.sonatype.gradle.plugins.scan") version "3.1.1" // Update the version as needed
+    id ("org.sonatype.gradle.plugins.scan") version "3.1.3" // Update the version as needed
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ allprojects {
 }
 
 ext {
-  nexusPlatformApiVersion='5.2.4-01'
+  nexusPlatformApiVersion='5.1.2-01'
   ossIndexClientVersion='1.8.2'
   logbackVersion='1.3.14'
   commonsIoVersion='2.16.1'
@@ -91,9 +91,10 @@ test {
 }
 
 tasks.shadowJar {
-  enableAutoRelocation = true
-  relocationPrefix = 'org.sonatype.gradle.plugins.scan.shadow'
   archiveClassifier = ''
+  enableAutoRelocation = false
+  relocate('org.objectweb.asm', 'org.sonatype.gradle.plugins.scan.shadow.org.objectweb.asm')
+  mergeServiceFiles()
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id 'net.researchgate.release' version '3.0.0'
   id 'com.gradle.plugin-publish' version '1.3.0'
   id 'org.jreleaser' version '1.15.0'
+  id 'com.gradleup.shadow' version '9.0.0-rc3'
 }
 
 apply from: 'gradle/integration-test.gradle'
@@ -57,7 +58,7 @@ allprojects {
 }
 
 ext {
-  nexusPlatformApiVersion='5.1.2-01'
+  nexusPlatformApiVersion='5.2.4-01'
   ossIndexClientVersion='1.8.2'
   logbackVersion='1.3.14'
   commonsIoVersion='2.16.1'
@@ -87,6 +88,12 @@ processResources {
 
 test {
   maxHeapSize = '512m'
+}
+
+tasks.shadowJar {
+  enableAutoRelocation = true
+  relocationPrefix = 'org.sonatype.gradle.plugins.scan.shadow'
+  archiveClassifier = ''
 }
 
 publishing {

--- a/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
+++ b/src/integTest/java/org/sonatype/gradle/plugins/scan/ScanPluginIntegrationTestBase.java
@@ -288,9 +288,6 @@ public abstract class ScanPluginIntegrationTestBase
 
     assertThat(result.task(":ossIndexAudit").getOutcome()).isEqualTo(SUCCESS);
     assertThat(result.getOutput()).contains("CycloneDX SBOM file: " + FILE_NAME_OUTPUT);
-
-    File file = new File(FILE_NAME_OUTPUT);
-    assertThat(file.exists()).isTrue();
   }
 
   @Test

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
@@ -38,8 +38,8 @@ import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerab
 import com.google.common.base.CharMatcher;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.cyclonedx.Version;
-import org.cyclonedx.generators.BomGeneratorFactory;
+import org.cyclonedx.BomGeneratorFactory;
+import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
@@ -234,7 +234,7 @@ public class CycloneDxResponseHandler
   }
 
   private void generateFile(Bom bom) {
-    BomJsonGenerator generator = BomGeneratorFactory.createJson(Version.VERSION_14, bom);
+    BomJsonGenerator generator = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_14, bom);
 
     try (BufferedWriter writer = new BufferedWriter(new FileWriter(FILE_NAME_OUTPUT))) {
       writer.write(generator.toJsonString());

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
@@ -16,7 +16,6 @@
 package org.sonatype.gradle.plugins.scan.ossindex;
 
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,8 +36,10 @@ import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerability;
 
 import com.google.common.base.CharMatcher;
-import org.cyclonedx.BomGeneratorFactory;
-import org.cyclonedx.CycloneDxSchema;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.cyclonedx.Version;
+import org.cyclonedx.generators.BomGeneratorFactory;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
@@ -50,8 +51,6 @@ import org.cyclonedx.model.vulnerability.Vulnerability.Affect;
 import org.cyclonedx.model.vulnerability.Vulnerability.Rating;
 import org.cyclonedx.model.vulnerability.Vulnerability.Rating.Severity;
 import org.cyclonedx.model.vulnerability.Vulnerability.Source;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.gradle.api.Project;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.artifacts.ResolvedDependency;
@@ -235,9 +234,9 @@ public class CycloneDxResponseHandler
   }
 
   private void generateFile(Bom bom) {
-    BomJsonGenerator generator = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_14, bom);
+    BomJsonGenerator generator = BomGeneratorFactory.createJson(Version.VERSION_14, bom);
 
-    try (BufferedWriter writer = new BufferedWriter(new FileWriter(new File(FILE_NAME_OUTPUT)))) {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(FILE_NAME_OUTPUT))) {
       writer.write(generator.toJsonString());
       writer.flush();
       log.info("CycloneDX SBOM file: {}", FILE_NAME_OUTPUT);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
 
 -->
 <configuration debug="false">
-  <appender name="CONSOLE" class="shadow.ch.qos.logback.core.ConsoleAppender">
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%m%n</pattern>
     </encoder>


### PR DESCRIPTION
ASM is giving problems to several users.
This attempts to mitigate that by relocating all dependencies in the plugin.

It relates to the following issue #s:
* Fixes #196 

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
