### PR TITLE
Issue 197 Changed nexus-platform-api version to support Java 21 hashing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ allprojects {
 }
 
 ext {
-  nexusPlatformApiVersion='5.1.2-01'
+  nexusPlatformApiVersion='5.2.4-01'
   ossIndexClientVersion='1.8.2'
   logbackVersion='1.3.14'
   commonsIoVersion='2.16.1'

--- a/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
+++ b/src/main/java/org/sonatype/gradle/plugins/scan/ossindex/CycloneDxResponseHandler.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
+import org.cyclonedx.CycloneDxSchema;
 import org.sonatype.goodies.packageurl.PackageUrl;
 import org.sonatype.gradle.plugins.scan.common.PluginVersionUtils;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
@@ -38,8 +39,8 @@ import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerab
 import com.google.common.base.CharMatcher;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.cyclonedx.BomGeneratorFactory;
-import org.cyclonedx.CycloneDxSchema;
+import org.cyclonedx.generators.BomGeneratorFactory;
+import org.cyclonedx.Version;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
@@ -234,7 +235,7 @@ public class CycloneDxResponseHandler
   }
 
   private void generateFile(Bom bom) {
-    BomJsonGenerator generator = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_14, bom);
+    BomJsonGenerator generator = BomGeneratorFactory.createJson(Version.VERSION_14, bom);
 
     try (BufferedWriter writer = new BufferedWriter(new FileWriter(FILE_NAME_OUTPUT))) {
       writer.write(generator.toJsonString());


### PR DESCRIPTION
Also resolved changes to CycloneDx

The update to the new nexus-platform-api version should resolve the problems with this plugin being used in projects that use Java 21, per the Nexus IQ release notes.  I didn't actually build and test locally, though, so this will need to be verified.

There were also several very small changes due to the CycloneDx dependency update included in the new version of nexus-platform-api.

It relates to the following issue #s:
* Fixes #197 

My apologies, but I haven't signed the Sonatype CLA, since the link doesn't seem to work.  I'll be glad to sign, if you update to a working link.

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
