### PR TITLE
Relocate org.apache.commons classes in order to avoid classpath conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ tasks.shadowJar {
   archiveClassifier = ''
   enableAutoRelocation = false
   relocate('org.objectweb.asm', 'org.sonatype.gradle.plugins.scan.shadow.org.objectweb.asm')
+  relocate('org.apache.commons', 'org.sonatype.gradle.plugins.scan.shadow.org.apache.commons')
   mergeServiceFiles()
 }
 


### PR DESCRIPTION
Hi! we are trying to adopt this plugin in https://github.com/open-telemetry/opentelemetry-java/pull/8186 but running into classpath conflicts due to the (older) version of `commons-lang3` bundled in this plugin's shadow jar.

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
