### PR TITLE
Exclude groovy asm so older versions of groovy do not conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ tasks.shadowJar {
   enableAutoRelocation = false
   relocate('org.objectweb.asm', 'org.sonatype.gradle.plugins.scan.shadow.org.objectweb.asm')
   relocate('org.apache.commons', 'org.sonatype.gradle.plugins.scan.shadow.org.apache.commons')
+  exclude 'groovyjarjarasm/**'
   mergeServiceFiles()
 }
 


### PR DESCRIPTION
groovyjarjarasm.asm is Groovy's internal shaded ASM. The version bundled here via nexus-platform-api (Groovy 2.4.21) only supports class files up to Java 16, and shadows Gradle's own copy (Groovy 3.x, supports Java 17+), breaking Java 17+ class file parsing in consumer builds. Gradle always provides a compatible copy at runtime via its own Groovy.

This pull request makes the following changes:
* excluding groovyjarjarasm/** 

It relates to the following issue #s:
* Fixes https://github.com/sonatype-nexus-community/scan-gradle-plugin/issues/206

I have created an example project here: https://github.com/jdaugherty/gradle-scan-plugin-asm-issue/blob/main/build.gradle and confirmed that when applying this fix, the issue is no longer present.  (publish to maven local & update to the snapshot version)

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
