### PR TITLE
feat: relocate jackson to avoid classpath conficts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ Sonatype internal people:
 External contributors:
 
 - [@JoarSvartholm](https://github.com/JoarSvartholm) (Joar Svartholm)
+- [@davidjlynn](https://github.com/davidjlynn) (David Lynn)
 - 
 
 Possibly You!

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ tasks.shadowJar {
   enableAutoRelocation = false
   relocate('org.objectweb.asm', 'org.sonatype.gradle.plugins.scan.shadow.org.objectweb.asm')
   relocate('org.apache.commons', 'org.sonatype.gradle.plugins.scan.shadow.org.apache.commons')
+  relocate('com.fasterxml.jackson', 'org.sonatype.gradle.plugins.scan.shadow.com.fasterxml.jackson')
   exclude 'groovyjarjarasm/**'
   mergeServiceFiles()
 }


### PR DESCRIPTION
When using this plugin, it transitively pulls in jackson on a specific version. 
This conflicts with other plugins (for example spring-boot-gradle-plugin). 
By relocating this conflict can be avoided.

This pull request makes the following changes:
* Fixes #210 : Relocate `com.fasterxml.jackson` to avoid conflicts with other gradle plugins.
* Added name to contributors, following contribution guidelines.

cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
